### PR TITLE
Use descriptive folder names for local downloads

### DIFF
--- a/blackpaint/src/index.ts
+++ b/blackpaint/src/index.ts
@@ -38,9 +38,10 @@ app.on('ready', () => {
 
   // This is our new "backend" logic
   ipcMain.handle(
-    'download-and-open-task-folder', 
-    async (_, taskId: string, filesToDownload: { filename: string, relativePath: string, url: string }[]) => {
-      const destinationFolder = path.join(app.getPath('downloads'), `Eldaline-Task-${taskId}`);
+    'download-and-open-task-folder',
+    async (_, folderName: string, filesToDownload: { filename: string, relativePath: string, url: string }[]) => {
+      const safeFolderName = folderName.replace(/[\\/:*?"<>|]/g, '').trim();
+      const destinationFolder = path.join(app.getPath('downloads'), safeFolderName);
       await fs.mkdir(destinationFolder, { recursive: true });
 
       const downloadPromises = filesToDownload.map(async (file) => {

--- a/blackpaint/src/preload.ts
+++ b/blackpaint/src/preload.ts
@@ -7,10 +7,10 @@ import { contextBridge, ipcRenderer } from 'electron';
 export const ELECTRON_API = {
   // We update the type definition for filesToDownload here
   downloadAndOpenTaskFolder: (
-    taskId: string, 
+    folderName: string,
     // This is the corrected type, now including relativePath
     filesToDownload: { filename: string, relativePath: string, url: string }[]
-  ) => ipcRenderer.invoke('download-and-open-task-folder', taskId, filesToDownload),
+  ) => ipcRenderer.invoke('download-and-open-task-folder', folderName, filesToDownload),
 };
 
 // Expose it securely

--- a/taintedpaint/components/KanbanDrawer.tsx
+++ b/taintedpaint/components/KanbanDrawer.tsx
@@ -14,7 +14,7 @@ declare global {
   interface Window {
     electronAPI?: {
       downloadAndOpenTaskFolder: (
-        taskId: string, 
+        folderName: string,
         filesToDownload: { filename: string, url: string }[]
       ) => Promise<void>;
     }
@@ -143,7 +143,8 @@ export default function KanbanDrawer({
       }
       
       // Step 2: Pass the list to the Electron main process to handle the download and open.
-      await window.electronAPI.downloadAndOpenTaskFolder(task.id, filesToDownload);
+      const folderName = `${task.customerName} - ${task.representative}`;
+      await window.electronAPI.downloadAndOpenTaskFolder(folderName, filesToDownload);
 
     } catch (error) {
       console.error("Download and open failed:", error);

--- a/taintedpaint/types/electron.d.ts
+++ b/taintedpaint/types/electron.d.ts
@@ -3,7 +3,7 @@
 // This interface must match the object exposed in preload.ts
 interface ElectronAPI {
   downloadAndOpenTaskFolder: (
-    taskId: string,
+    folderName: string,
     // This signature must match the one in preload.ts
     filesToDownload: { filename: string, relativePath: string, url: string }[]
   ) => Promise<void>;


### PR DESCRIPTION
## Summary
- expose folder name in preload script and types
- sanitize provided folder name in the Electron handler
- update Kanban drawer to pass `customerName - representative`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run lint` in `blackpaint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6879f847a460832db08f00928548064c