### PR TITLE
Revamp Kanban drawer UI

### DIFF
--- a/taintedpaint/components/KanbanDrawer.tsx
+++ b/taintedpaint/components/KanbanDrawer.tsx
@@ -4,8 +4,8 @@
 
 import type { Task } from "@/types";
 import type React from "react";
-import { useState, useRef, useCallback } from "react";
-import { X, FileText, CalendarDays, MessageSquare, Plus, Loader2, Trash2, Folder } from "lucide-react";
+import { useState, useCallback } from "react";
+import { X, CalendarDays, MessageSquare, Loader2, Folder } from "lucide-react";
 
 // The 'window.electronAPI' object is injected by the Electron preload script.
 // To make TypeScript aware of it, you would typically have a declaration file
@@ -27,7 +27,6 @@ interface KanbanDrawerProps {
   task: Task | null;
   columnTitle: string | null;
   onClose: () => void;
-  onTaskUpdated: (updatedTask: Task) => void;
 }
 
 const truncateFilename = (name: string, maxLength = 25) => {
@@ -45,81 +44,12 @@ export default function KanbanDrawer({
   task,
   columnTitle,
   onClose,
-  onTaskUpdated,
 }: KanbanDrawerProps) {
   // --- UI & API State ---
-  const [isDraggingOver, setIsDraggingOver] = useState(false);
-  const [isUploading, setIsUploading] = useState(false);
-  const [updatingFile, setUpdatingFile] = useState<string | null>(null);
-  const [deletingFile, setDeletingFile] = useState<string | null>(null);
-  
-  // NEW state for the Electron download process
+  // Electron open progress state
   const [isDownloading, setIsDownloading] = useState(false);
 
-  // --- Refs for file inputs ---
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const updateFileInputRef = useRef<HTMLInputElement>(null);
-  const fileToUpdateRef = useRef<string | null>(null);
-
-  // --- [UNCHANGED] API Call: Upload new files via Next.js API ---
-  const handleFileUpload = useCallback(async (files: FileList | null) => {
-    if (!task || !files || files.length === 0) return;
-    setIsUploading(true);
-    const formData = new FormData();
-    Array.from(files).forEach((file) => formData.append("files", file));
-    try {
-      const res = await fetch(`/api/jobs/${task.id}/upload`, { method: "POST", body: formData });
-      if (!res.ok) throw new Error("File upload failed");
-      const updatedTask = await res.json();
-      onTaskUpdated(updatedTask);
-    } catch (error) {
-      console.error("Upload failed:", error);
-    } finally {
-      setIsUploading(false);
-    }
-  }, [task, onTaskUpdated]);
-
-  // --- [UNCHANGED] API Call: Update a single existing file via Next.js API ---
-  const handleFileUpdate = useCallback(async (newFile: File, oldFilename: string) => {
-    if (!task) return;
-    setUpdatingFile(oldFilename);
-    const formData = new FormData();
-    formData.append("newFile", newFile);
-    formData.append("oldFilename", oldFilename);
-    try {
-      const res = await fetch(`/api/jobs/${task.id}/update-file`, { method: "POST", body: formData });
-      if (!res.ok) throw new Error(await res.json().then(e => e.error || "File update failed"));
-      const updatedTask = await res.json();
-      onTaskUpdated(updatedTask);
-    } catch (error) {
-      console.error("Update failed:", error);
-    } finally {
-      setUpdatingFile(null);
-    }
-  }, [task, onTaskUpdated]);
-
-  // --- [UNCHANGED] API Call: Delete a single file via Next.js API ---
-  const handleFileDelete = useCallback(async (filename: string) => {
-    if (!task) return;
-    const isConfirmed = window.confirm(`你确定要删除文件 "${filename}" 吗？此操作无法撤销。`);
-    if (!isConfirmed) return;
-
-    setDeletingFile(filename);
-    try {
-      const res = await fetch(`/api/jobs/${task.id}/delete-file`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ filename }),
-      });
-      if (!res.ok) throw new Error(await res.json().then(e => e.error || "File deletion failed"));
-      const updatedTask = await res.json();
-      onTaskUpdated(updatedTask);
-    } catch (error) {
-      console.error("Deletion failed:", error);
-    } finally {
-      setDeletingFile(null);
-    }
-  }, [task, onTaskUpdated]);
+  // --- [Electron] Open the synced folder ---
   
   // --- [NEW] Electron-powered download handler ---
   const handleDownloadAndOpen = useCallback(async () => {
@@ -156,20 +86,6 @@ export default function KanbanDrawer({
   }, [task]);
 
 
-  // --- UI Handlers (unchanged) ---
-  const handleUpdateClick = (filename: string) => {
-    fileToUpdateRef.current = filename;
-    updateFileInputRef.current?.click();
-  };
-
-  const handleFileUpdateSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newFile = e.target.files?.[0];
-    const oldFilename = fileToUpdateRef.current;
-    if (newFile && oldFilename) {
-      handleFileUpdate(newFile, oldFilename);
-    }
-    if (e.target) e.target.value = "";
-  };
   
   if (!task) {
     return (
@@ -177,20 +93,12 @@ export default function KanbanDrawer({
     );
   }
   
-  const files = task.files || [];
-
   return (
     <aside
       className={`fixed inset-y-0 right-0 w-[400px] bg-white/95 backdrop-blur-xl border-l border-black/[0.08] 
                  transition-transform duration-400 ease-[cubic-bezier(0.32,0.72,0,1)] z-50 flex flex-col
                  ${isOpen ? "translate-x-0 shadow-[0_8px_64px_0_rgba(0,0,0,0.25)]" : "translate-x-full"}`}
       onClick={(e) => e.stopPropagation()}
-      onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); setIsDraggingOver(true); }}
-      onDragLeave={(e) => { e.preventDefault(); e.stopPropagation(); setIsDraggingOver(false); }}
-      onDrop={(e) => {
-        e.preventDefault(); e.stopPropagation(); setIsDraggingOver(false);
-        handleFileUpload(e.dataTransfer.files);
-      }}
     >
       <div className="flex-shrink-0 px-6 pt-6 pb-0 flex items-start justify-between">
         <div className="flex-1 min-w-0 pr-4">
@@ -225,73 +133,20 @@ export default function KanbanDrawer({
         </div>
 
         <div className="space-y-4">
-          <h3 className="text-[17px] font-medium text-black">项目文件</h3>
-          
-          {files.length > 0 && (
-            <div className="bg-black/[0.02] rounded-2xl p-4 space-y-2">
-              {files.map((name) => (
-                <div key={name} className="flex items-center gap-3 p-2 rounded-lg hover:bg-black/[0.04] transition-colors duration-150 group">
-                  <FileText className="h-4 w-4 text-black/40 flex-shrink-0" />
-                  <span className="text-[14px] text-black/70 truncate flex-1" title={name}>{truncateFilename(name)}</span>
-                  <div className="flex items-center justify-end gap-2 w-24 opacity-0 group-hover:opacity-100 transition-opacity">
-                    {updatingFile === name || deletingFile === name ? (
-                      <Loader2 className="h-4 w-4 animate-spin text-black/50" />
-                    ) : (
-                      <>
-                        <button onClick={() => handleUpdateClick(name)} className="text-[13px] font-medium text-blue-600 hover:text-blue-500">更新</button>
-                        <button onClick={() => handleFileDelete(name)} className="text-[13px] font-medium text-red-600 hover:text-red-500">删除</button>
-                      </>
-                    )}
-                  </div>
-                </div>
-              ))}
+          <button
+            onClick={handleDownloadAndOpen}
+            disabled={isDownloading}
+            className="w-full flex items-center gap-4 p-4 bg-neutral-100 hover:bg-neutral-200 rounded-2xl transition-all duration-200 disabled:opacity-60 disabled:cursor-wait"
+          >
+            <div className="flex items-center justify-center h-10 w-10 rounded-full bg-neutral-200 group-hover:bg-neutral-300 transition-colors duration-200">
+              {isDownloading ? <Loader2 className="h-5 w-5 animate-spin text-neutral-600" /> : <Folder className="h-5 w-5 text-neutral-600" />}
             </div>
-          )}
-
-          {/* Action buttons... */}
-          <div className="space-y-3">
-            {files.length > 0 && (
-              // --- THIS IS THE UPDATED BUTTON ---
-              <button onClick={handleDownloadAndOpen} disabled={isDownloading} className="w-full flex items-center gap-4 p-4 bg-green-500/8 hover:bg-green-500/12 rounded-2xl transition-all duration-200 group disabled:opacity-60 disabled:cursor-wait">
-                <div className="flex items-center justify-center h-10 w-10 rounded-full bg-green-500/15 group-hover:bg-green-500/20 transition-colors duration-200">
-                  {isDownloading ? <Loader2 className="h-5 w-5 text-green-600 animate-spin" /> : <Folder className="h-5 w-5 text-green-600" />}
-                </div>
-                <div className="flex-1 text-left">
-                  <p className="text-[15px] font-medium text-black">{isDownloading ? '正在下载...' : '下载并打开文件夹'}</p>
-                  <p className="text-[13px] text-black/50">{isDownloading ? '文件将保存在您的下载目录' : '快速获取所有项目文件'}</p>
-                </div>
-              </button>
-            )}
-
-            <div className="relative">
-              {isUploading && (
-                <div className="absolute inset-0 bg-white/80 backdrop-blur-sm flex items-center justify-center rounded-2xl z-10">
-                  <div className="flex items-center gap-2"><Loader2 className="h-5 w-5 text-black/60 animate-spin" /><span className="text-[15px] text-black/60">上传中...</span></div>
-                </div>
-              )}
-              <label htmlFor="drawer-file-upload" className={`block w-full p-5 cursor-pointer rounded-2xl transition-all duration-200 border-2 border-dashed group ${
-                isDraggingOver ? "bg-green-50/80 border-green-400/60 ring-4 ring-green-500/10" : files.length > 0 ? "bg-black/[0.02] border-black/10 hover:bg-black/[0.04] hover:border-black/20" : "bg-blue-50/50 border-blue-200/60 hover:bg-blue-50/80 hover:border-blue-300/80"
-              }`}>
-                <div className="flex items-center gap-4">
-                  <div className={`flex items-center justify-center h-10 w-10 rounded-full transition-colors duration-200 ${
-                    isDraggingOver ? 'bg-green-500/15' : files.length > 0 ? 'bg-black/8 group-hover:bg-black/12' : 'bg-blue-500/15 group-hover:bg-blue-500/20'
-                  }`}>
-                    <Plus className={`h-5 w-5 transition-colors duration-200 ${
-                      isDraggingOver ? 'text-green-600' : files.length > 0 ? 'text-black/60' : 'text-blue-600'
-                    }`} />
-                  </div>
-                  <div className="flex-1 text-left">
-                    <p className="text-[15px] font-medium text-black">{files.length === 0 ? "上传项目文件" : "上传更新文件"}</p>
-                    <p className="text-[13px] text-black/50">{files.length === 0 ? "拖放文件或点击选择" : "添加修改后的文件或新内容"}</p>
-                  </div>
-                </div>
-              </label>
-              <input id="drawer-file-upload" type="file" multiple ref={fileInputRef} className="hidden" onChange={(e) => handleFileUpload(e.target.files)} />
+            <div className="flex-1 text-left">
+              <p className="text-[15px] font-medium text-black">{isDownloading ? '打开中...' : '打开文件夹'}</p>
             </div>
-          </div>
+          </button>
         </div>
       </div>
-      <input type="file" ref={updateFileInputRef} className="hidden" onChange={handleFileUpdateSelected} />
     </aside>
   );
 }


### PR DESCRIPTION
## Summary
- remove upload/update/delete features from Kanban drawer
- keep minimal drawer for opening synced folder

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a0c5c4ce4832dbdb811aaa50bda5d