### PR TITLE
Fix metadata writes and file sync errors

### DIFF
--- a/taintedpaint/app/api/jobs/[taskId]/delete-file/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/delete-file/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { promises as fs } from "fs";
 import path from "path";
 import type { BoardData } from "@/types";
+import { writeJsonAtomic } from "@/lib/fileUtils";
 
 // --- Path Definitions ---
 const STORAGE_DIR = path.join(process.cwd(), "public", "storage");
@@ -55,7 +56,7 @@ export async function POST(
     }
 
     // 4. Write the updated metadata back
-    await fs.writeFile(META_FILE, JSON.stringify(boardData, null, 2));
+    await writeJsonAtomic(META_FILE, boardData);
 
     // 5. Return the fully updated task object to the client
     return NextResponse.json(taskToUpdate);

--- a/taintedpaint/app/api/jobs/[taskId]/files/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/files/route.ts
@@ -56,7 +56,7 @@ export async function GET(
   req: NextRequest,
   { params }: { params: { taskId: string } }
 ) {
-  const { taskId } = params;
+  const { taskId } = await params;
   if (!taskId) {
     return NextResponse.json({ error: "Task ID is required" }, { status: 400 });
   }

--- a/taintedpaint/app/api/jobs/[taskId]/update-file/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/update-file/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { promises as fs } from "fs";
 import path from "path";
 import type { BoardData } from "@/types";
+import { writeJsonAtomic } from "@/lib/fileUtils";
 
 const STORAGE_DIR = path.join(process.cwd(), "public", "storage");
 const TASKS_STORAGE_DIR = path.join(STORAGE_DIR, "tasks");
@@ -67,7 +68,7 @@ export async function POST(
       taskToUpdate.files = [...(taskToUpdate.files || []), newPath];
     }
 
-    await fs.writeFile(META_FILE, JSON.stringify(boardData, null, 2));
+    await writeJsonAtomic(META_FILE, boardData);
 
     return NextResponse.json(taskToUpdate);
   } catch (err) {

--- a/taintedpaint/app/api/jobs/[taskId]/upload/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/upload/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { promises as fs } from "fs";
 import path from "path";
 import type { BoardData } from "@/types";
+import { writeJsonAtomic } from "@/lib/fileUtils";
 
 // --- Path Definitions ---
 const STORAGE_DIR = path.join(process.cwd(), "public", "storage");
@@ -60,7 +61,7 @@ export async function POST(
     taskToUpdate.files.push(...newlyAddedFiles);
     // ----------------------------------------------------------------------
 
-    await fs.writeFile(META_FILE, JSON.stringify(boardData, null, 2));
+    await writeJsonAtomic(META_FILE, boardData);
 
     return NextResponse.json(taskToUpdate);
   } catch (err) {

--- a/taintedpaint/app/api/jobs/route.ts
+++ b/taintedpaint/app/api/jobs/route.ts
@@ -5,6 +5,7 @@ import { promises as fs } from "fs";
 import path from "path";
 import type { BoardData, Column, Task } from "@/types";
 import { baseColumns, START_COLUMN_ID } from "@/lib/baseColumns";
+import { writeJsonAtomic } from "@/lib/fileUtils";
 
 // --- Path Definitions ---
 const STORAGE_DIR = path.join(process.cwd(), "public", "storage");
@@ -101,7 +102,7 @@ export async function POST(req: NextRequest) {
       boardData.columns[0].taskIds.push(taskId);
     }
 
-    await fs.writeFile(META_FILE, JSON.stringify(boardData, null, 2));
+    await writeJsonAtomic(META_FILE, boardData);
 
     return NextResponse.json(newTask);
   } catch (err) {
@@ -117,7 +118,7 @@ export async function PUT(req: NextRequest) {
     if (!boardData.tasks || !boardData.columns) {
       return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
     }
-    await fs.writeFile(META_FILE, JSON.stringify(boardData, null, 2));
+    await writeJsonAtomic(META_FILE, boardData);
     return NextResponse.json({ ok: true });
   } catch (err) {
     console.error("Failed to update board:", err);

--- a/taintedpaint/lib/fileUtils.ts
+++ b/taintedpaint/lib/fileUtils.ts
@@ -1,0 +1,7 @@
+import { promises as fs } from 'fs'
+
+export async function writeJsonAtomic(filePath: string, data: any) {
+  const tempPath = filePath + '.tmp'
+  await fs.writeFile(tempPath, JSON.stringify(data, null, 2))
+  await fs.rename(tempPath, filePath)
+}


### PR DESCRIPTION
## Summary
- prevent uploading directories by checking for files
- avoid watcher errors when directories are renamed
- ensure metadata writes are atomic via `writeJsonAtomic`
- update routes to use the new helper and wait for params
- fix TypeScript timer type

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run lint` in blackpaint *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_687a106fcd3c832d9390e880738f667a