### PR TITLE
Fix metadata write race condition

### DIFF
--- a/blackpaint/src/sync.ts
+++ b/blackpaint/src/sync.ts
@@ -10,7 +10,7 @@ interface RemoteFile {
   mtimeMs: number;
 }
 
-const activeSyncs = new Map<string, { watcher: FSWatcher; interval: NodeJS.Timeout }>();
+const activeSyncs = new Map<string, { watcher: FSWatcher; interval: ReturnType<typeof setInterval> }>();
 
 // Simple helper to upload or update a file
 async function uploadFile(taskId: string, localRoot: string, relPath: string) {

--- a/taintedpaint/lib/fileUtils.ts
+++ b/taintedpaint/lib/fileUtils.ts
@@ -1,7 +1,13 @@
 import { promises as fs } from 'fs'
+import { randomUUID } from 'crypto'
 
 export async function writeJsonAtomic(filePath: string, data: any) {
-  const tempPath = filePath + '.tmp'
+  // Use a unique temporary file so concurrent writes don't interfere
+  const tempPath = `${filePath}.${randomUUID()}.tmp`
+
+  // Write the entire JSON to the temp file first
   await fs.writeFile(tempPath, JSON.stringify(data, null, 2))
+
+  // Atomically replace the target file
   await fs.rename(tempPath, filePath)
 }


### PR DESCRIPTION
## Summary
- ensure concurrent metadata writes use unique temp file
- fix typing for sync timers

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run lint` in `blackpaint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_687a137fc498832d858b24973c08397a