### PR TITLE
Add production ID display after approval

### DIFF
--- a/taintedpaint/components/KanbanDrawer.tsx
+++ b/taintedpaint/components/KanbanDrawer.tsx
@@ -144,7 +144,7 @@ export default function KanbanDrawer({
       }
       
       // Step 2: Pass the list to the Electron main process to handle the download and open.
-      const folderName = `${task.customerName} - ${task.representative}`;
+      const folderName = task.ynmxId || `${task.customerName} - ${task.representative}`;
       await window.electronAPI.downloadAndOpenTaskFolder(task.id, folderName, filesToDownload);
 
     } catch (error) {
@@ -194,12 +194,14 @@ export default function KanbanDrawer({
     >
       <div className="flex-shrink-0 px-6 pt-6 pb-0 flex items-start justify-between">
         <div className="flex-1 min-w-0 pr-4">
-          <h1 className="text-xl font-semibold text-black tracking-tight truncate -mb-0.5">{task.customerName}</h1>
+          <h1 className="text-xl font-semibold text-black tracking-tight truncate -mb-0.5">{task.ynmxId || task.customerName}</h1>
           <div className="flex items-center gap-2 mt-1">
-            <p className="text-[15px] text-black/60 truncate">{task.representative}</p>
+            {!task.ynmxId && (
+              <p className="text-[15px] text-black/60 truncate">{task.representative}</p>
+            )}
             {columnTitle && (
               <>
-                <span className="text-black/30 text-sm">·</span>
+                {!task.ynmxId && <span className="text-black/30 text-sm">·</span>}
                 <span className="text-[13px] font-medium text-black/50 bg-black/5 px-2 py-0.5 rounded-full">{columnTitle}</span>
               </>
             )}

--- a/taintedpaint/components/SearchDialog.tsx
+++ b/taintedpaint/components/SearchDialog.tsx
@@ -152,7 +152,9 @@ export default function SearchDialog({ isOpen, onClose, onTaskSelect }: SearchDi
                   </div>
                   <div className="flex-1 min-w-0">
                     <h3 className="text-sm font-semibold text-gray-800 truncate">
-                      {`${task.customerName} - ${task.representative}`}
+                      {['approval', 'production'].includes(task.columnId)
+                        ? task.ynmxId || `${task.customerName} - ${task.representative}`
+                        : `${task.customerName} - ${task.representative}`}
                     </h3>
                     <p className="text-xs text-gray-600">{task.orderDate}</p>
                   </div>

--- a/taintedpaint/types.ts
+++ b/taintedpaint/types.ts
@@ -9,6 +9,7 @@ export interface Task {
   notes: string;
   taskFolderPath: string;
   files: string[];
+  ynmxId?: string; // ID assigned when moving to approval
 }
 
 export interface Column {


### PR DESCRIPTION
## Summary
- generate daily sequential YNMX IDs for tasks
- show the ID instead of customer info once tasks reach approval
- hide customer info in drawer and search dialog for approved tasks
- use the ID for download folder names

## Testing
- `npm install` *(fails: registry access blocked)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a23c956f8832da1ac7e044ba1b63f