### PR TITLE
Add metadata view to Kanban drawer

### DIFF
--- a/taintedpaint/components/KanbanDrawer.tsx
+++ b/taintedpaint/components/KanbanDrawer.tsx
@@ -1,299 +1,168 @@
 // file: components/KanbanDrawer.tsx
-
 "use client";
 
 import type { Task } from "@/types";
-import type React from "react";
-import { useState, useRef, useCallback } from "react";
-import { X, FileText, CalendarDays, MessageSquare, Plus, Loader2, Trash2, Folder } from "lucide-react";
-
-// The 'window.electronAPI' object is injected by the Electron preload script.
-// To make TypeScript aware of it, you would typically have a declaration file
-// (e.g., 'electron.d.ts') in your project.
-declare global {
-  interface Window {
-    electronAPI?: {
-      downloadAndOpenTaskFolder: (
-        taskId: string,
-        folderName: string,
-        filesToDownload: { filename: string, url: string; relativePath: string }[]
-      ) => Promise<void>;
-    }
-  }
-}
+import { useState, useCallback } from "react";
+import { X, CalendarDays, MessageSquare, Folder, FileCode } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 
 interface KanbanDrawerProps {
   isOpen: boolean;
   task: Task | null;
   columnTitle: string | null;
   onClose: () => void;
-  onTaskUpdated: (updatedTask: Task) => void;
 }
-
-const truncateFilename = (name: string, maxLength = 25) => {
-  if (name.length <= maxLength) return name;
-  const extMatch = name.match(/\.[^./]+$/);
-  const ext = extMatch ? extMatch[0] : "";
-  const core = name.replace(ext, "");
-  const coreMaxLength = maxLength - ext.length - 1;
-  if (coreMaxLength <= 3) return name;
-  return `${core.slice(0, coreMaxLength)}…${ext}`;
-};
 
 export default function KanbanDrawer({
   isOpen,
   task,
   columnTitle,
   onClose,
-  onTaskUpdated,
 }: KanbanDrawerProps) {
-  // --- UI & API State ---
-  const [isDraggingOver, setIsDraggingOver] = useState(false);
-  const [isUploading, setIsUploading] = useState(false);
-  const [updatingFile, setUpdatingFile] = useState<string | null>(null);
-  const [deletingFile, setDeletingFile] = useState<string | null>(null);
-  
-  // NEW state for the Electron download process
   const [isDownloading, setIsDownloading] = useState(false);
+  const [showMetadata, setShowMetadata] = useState(false);
 
-  // --- Refs for file inputs ---
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const updateFileInputRef = useRef<HTMLInputElement>(null);
-  const fileToUpdateRef = useRef<string | null>(null);
-
-  // --- [UNCHANGED] API Call: Upload new files via Next.js API ---
-  const handleFileUpload = useCallback(async (files: FileList | null) => {
-    if (!task || !files || files.length === 0) return;
-    setIsUploading(true);
-    const formData = new FormData();
-    Array.from(files).forEach((file) => formData.append("files", file));
-    try {
-      const res = await fetch(`/api/jobs/${task.id}/upload`, { method: "POST", body: formData });
-      if (!res.ok) throw new Error("File upload failed");
-      const updatedTask = await res.json();
-      onTaskUpdated(updatedTask);
-    } catch (error) {
-      console.error("Upload failed:", error);
-    } finally {
-      setIsUploading(false);
-    }
-  }, [task, onTaskUpdated]);
-
-  // --- [UNCHANGED] API Call: Update a single existing file via Next.js API ---
-  const handleFileUpdate = useCallback(async (newFile: File, oldFilename: string) => {
-    if (!task) return;
-    setUpdatingFile(oldFilename);
-    const formData = new FormData();
-    formData.append("newFile", newFile);
-    formData.append("oldFilename", oldFilename);
-    try {
-      const res = await fetch(`/api/jobs/${task.id}/update-file`, { method: "POST", body: formData });
-      if (!res.ok) throw new Error(await res.json().then(e => e.error || "File update failed"));
-      const updatedTask = await res.json();
-      onTaskUpdated(updatedTask);
-    } catch (error) {
-      console.error("Update failed:", error);
-    } finally {
-      setUpdatingFile(null);
-    }
-  }, [task, onTaskUpdated]);
-
-  // --- [UNCHANGED] API Call: Delete a single file via Next.js API ---
-  const handleFileDelete = useCallback(async (filename: string) => {
-    if (!task) return;
-    const isConfirmed = window.confirm(`你确定要删除文件 "${filename}" 吗？此操作无法撤销。`);
-    if (!isConfirmed) return;
-
-    setDeletingFile(filename);
-    try {
-      const res = await fetch(`/api/jobs/${task.id}/delete-file`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ filename }),
-      });
-      if (!res.ok) throw new Error(await res.json().then(e => e.error || "File deletion failed"));
-      const updatedTask = await res.json();
-      onTaskUpdated(updatedTask);
-    } catch (error) {
-      console.error("Deletion failed:", error);
-    } finally {
-      setDeletingFile(null);
-    }
-  }, [task, onTaskUpdated]);
-  
-  // --- [NEW] Electron-powered download handler ---
   const handleDownloadAndOpen = useCallback(async () => {
     if (!task) return;
-
-    // This is the crucial check. If 'window.electronAPI' doesn't exist, we're in a regular browser.
     if (!window.electronAPI) {
       alert("此功能仅在桌面应用中可用。请下载桌面版以获得最佳体验。");
       return;
     }
-    
     setIsDownloading(true);
     try {
-      // Step 1: Get the list of file URLs from our Next.js backend.
       const res = await fetch(`/api/jobs/${task.id}/files`);
-      if (!res.ok) throw new Error('无法获取文件列表');
+      if (!res.ok) throw new Error("无法获取文件列表");
       const filesToDownload: { filename: string; url: string; relativePath: string }[] = await res.json();
-      
       if (filesToDownload.length === 0) {
         alert("此任务没有可下载的文件。");
         return;
       }
-      
-      // Step 2: Pass the list to the Electron main process to handle the download and open.
       const folderName = task.ynmxId || `${task.customerName} - ${task.representative}`;
       await window.electronAPI.downloadAndOpenTaskFolder(task.id, folderName, filesToDownload);
-
-    } catch (error) {
-      console.error("Download and open failed:", error);
-      alert(`下载失败: ${error.message}`);
+    } catch (err: any) {
+      console.error("Download and open failed:", err);
+      alert(`下载失败: ${err.message}`);
     } finally {
       setIsDownloading(false);
     }
   }, [task]);
 
-
-  // --- UI Handlers (unchanged) ---
-  const handleUpdateClick = (filename: string) => {
-    fileToUpdateRef.current = filename;
-    updateFileInputRef.current?.click();
-  };
-
-  const handleFileUpdateSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newFile = e.target.files?.[0];
-    const oldFilename = fileToUpdateRef.current;
-    if (newFile && oldFilename) {
-      handleFileUpdate(newFile, oldFilename);
-    }
-    if (e.target) e.target.value = "";
-  };
-  
   if (!task) {
     return (
       <aside className="fixed inset-y-0 right-0 w-[400px] translate-x-full pointer-events-none transition-transform duration-400 ease-[cubic-bezier(0.32,0.72,0,1)]" />
     );
   }
-  
-  const files = task.files || [];
 
   return (
-    <aside
-      className={`fixed inset-y-0 right-0 w-[400px] bg-white/95 backdrop-blur-xl border-l border-black/[0.08] 
-                 transition-transform duration-400 ease-[cubic-bezier(0.32,0.72,0,1)] z-50 flex flex-col
-                 ${isOpen ? "translate-x-0 shadow-[0_8px_64px_0_rgba(0,0,0,0.25)]" : "translate-x-full"}`}
-      onClick={(e) => e.stopPropagation()}
-      onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); setIsDraggingOver(true); }}
-      onDragLeave={(e) => { e.preventDefault(); e.stopPropagation(); setIsDraggingOver(false); }}
-      onDrop={(e) => {
-        e.preventDefault(); e.stopPropagation(); setIsDraggingOver(false);
-        handleFileUpload(e.dataTransfer.files);
-      }}
-    >
-      <div className="flex-shrink-0 px-6 pt-6 pb-0 flex items-start justify-between">
-        <div className="flex-1 min-w-0 pr-4">
-          <h1 className="text-xl font-semibold text-black tracking-tight truncate -mb-0.5">{task.ynmxId || task.customerName}</h1>
-          <div className="flex items-center gap-2 mt-1">
-            {!task.ynmxId && (
-              <p className="text-[15px] text-black/60 truncate">{task.representative}</p>
-            )}
-            {columnTitle && (
-              <>
-                {!task.ynmxId && <span className="text-black/30 text-sm">·</span>}
-                <span className="text-[13px] font-medium text-black/50 bg-black/5 px-2 py-0.5 rounded-full">{columnTitle}</span>
-              </>
-            )}
-          </div>
-        </div>
-        <button onClick={onClose} className="flex-shrink-0 h-8 w-8 flex items-center justify-center rounded-full bg-black/5 hover:bg-black/10 transition-colors duration-200">
-          <X className="h-4 w-4 text-black/60" />
-        </button>
-      </div>
-
-      <div className="flex-1 overflow-y-auto px-6 pt-6 pb-6">
-        <div className="space-y-3 mb-8">
-          <div className="flex items-center justify-between py-3 border-b border-black/[0.08]">
-            <div className="flex items-center gap-3"><CalendarDays className="h-4 w-4 text-black/40" /><span className="text-[15px] text-black/60">订单日期</span></div>
-            <span className="text-[15px] font-medium text-black">{task.orderDate}</span>
-          </div>
-          {task.notes && (
-            <div className="py-3 border-b border-black/[0.08]">
-              <div className="flex items-center gap-3 mb-2"><MessageSquare className="h-4 w-4 text-black/40" /><span className="text-[15px] text-black/60">备注</span></div>
-              <p className="text-[15px] text-black leading-relaxed ml-7">{task.notes}</p>
-            </div>
-          )}
-        </div>
-
-        <div className="space-y-4">
-          <h3 className="text-[17px] font-medium text-black">项目文件</h3>
-          
-          {files.length > 0 && (
-            <div className="bg-black/[0.02] rounded-2xl p-4 space-y-2">
-              {files.map((name) => (
-                <div key={name} className="flex items-center gap-3 p-2 rounded-lg hover:bg-black/[0.04] transition-colors duration-150 group">
-                  <FileText className="h-4 w-4 text-black/40 flex-shrink-0" />
-                  <span className="text-[14px] text-black/70 truncate flex-1" title={name}>{truncateFilename(name)}</span>
-                  <div className="flex items-center justify-end gap-2 w-24 opacity-0 group-hover:opacity-100 transition-opacity">
-                    {updatingFile === name || deletingFile === name ? (
-                      <Loader2 className="h-4 w-4 animate-spin text-black/50" />
-                    ) : (
-                      <>
-                        <button onClick={() => handleUpdateClick(name)} className="text-[13px] font-medium text-blue-600 hover:text-blue-500">更新</button>
-                        <button onClick={() => handleFileDelete(name)} className="text-[13px] font-medium text-red-600 hover:text-red-500">删除</button>
-                      </>
-                    )}
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-
-          {/* Action buttons... */}
-          <div className="space-y-3">
-            {files.length > 0 && (
-              // --- THIS IS THE UPDATED BUTTON ---
-              <button onClick={handleDownloadAndOpen} disabled={isDownloading} className="w-full flex items-center gap-4 p-4 bg-green-500/8 hover:bg-green-500/12 rounded-2xl transition-all duration-200 group disabled:opacity-60 disabled:cursor-wait">
-                <div className="flex items-center justify-center h-10 w-10 rounded-full bg-green-500/15 group-hover:bg-green-500/20 transition-colors duration-200">
-                  {isDownloading ? <Loader2 className="h-5 w-5 text-green-600 animate-spin" /> : <Folder className="h-5 w-5 text-green-600" />}
-                </div>
-                <div className="flex-1 text-left">
-                  <p className="text-[15px] font-medium text-black">{isDownloading ? '正在下载...' : '下载并打开文件夹'}</p>
-                  <p className="text-[13px] text-black/50">{isDownloading ? '文件将保存在您的下载目录' : '快速获取所有项目文件'}</p>
-                </div>
-              </button>
-            )}
-
-            <div className="relative">
-              {isUploading && (
-                <div className="absolute inset-0 bg-white/80 backdrop-blur-sm flex items-center justify-center rounded-2xl z-10">
-                  <div className="flex items-center gap-2"><Loader2 className="h-5 w-5 text-black/60 animate-spin" /><span className="text-[15px] text-black/60">上传中...</span></div>
-                </div>
+    <>
+      <aside
+        className={`fixed inset-y-0 right-0 w-[400px] bg-white/95 backdrop-blur-xl border-l border-black/[0.08] transition-transform duration-400 ease-[cubic-bezier(0.32,0.72,0,1)] z-50 flex flex-col ${isOpen ? "translate-x-0 shadow-[0_8px_64px_0_rgba(0,0,0,0.25)]" : "translate-x-full"}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex-shrink-0 px-6 pt-6 pb-0 flex items-start justify-between">
+          <div className="flex-1 min-w-0 pr-4">
+            <h1 className="text-xl font-semibold text-black tracking-tight truncate -mb-0.5">
+              {task.ynmxId || task.customerName}
+            </h1>
+            <div className="flex items-center gap-2 mt-1">
+              {!task.ynmxId && (
+                <p className="text-[15px] text-black/60 truncate">{task.representative}</p>
               )}
-              <label htmlFor="drawer-file-upload" className={`block w-full p-5 cursor-pointer rounded-2xl transition-all duration-200 border-2 border-dashed group ${
-                isDraggingOver ? "bg-green-50/80 border-green-400/60 ring-4 ring-green-500/10" : files.length > 0 ? "bg-black/[0.02] border-black/10 hover:bg-black/[0.04] hover:border-black/20" : "bg-blue-50/50 border-blue-200/60 hover:bg-blue-50/80 hover:border-blue-300/80"
-              }`}>
-                <div className="flex items-center gap-4">
-                  <div className={`flex items-center justify-center h-10 w-10 rounded-full transition-colors duration-200 ${
-                    isDraggingOver ? 'bg-green-500/15' : files.length > 0 ? 'bg-black/8 group-hover:bg-black/12' : 'bg-blue-500/15 group-hover:bg-blue-500/20'
-                  }`}>
-                    <Plus className={`h-5 w-5 transition-colors duration-200 ${
-                      isDraggingOver ? 'text-green-600' : files.length > 0 ? 'text-black/60' : 'text-blue-600'
-                    }`} />
-                  </div>
-                  <div className="flex-1 text-left">
-                    <p className="text-[15px] font-medium text-black">{files.length === 0 ? "上传项目文件" : "上传更新文件"}</p>
-                    <p className="text-[13px] text-black/50">{files.length === 0 ? "拖放文件或点击选择" : "添加修改后的文件或新内容"}</p>
-                  </div>
-                </div>
-              </label>
-              <input id="drawer-file-upload" type="file" multiple ref={fileInputRef} className="hidden" onChange={(e) => handleFileUpload(e.target.files)} />
+              {columnTitle && (
+                <>
+                  {!task.ynmxId && <span className="text-black/30 text-sm">·</span>}
+                  <span className="text-[13px] font-medium text-black/50 bg-black/5 px-2 py-0.5 rounded-full">
+                    {columnTitle}
+                  </span>
+                </>
+              )}
             </div>
           </div>
+          <button
+            onClick={onClose}
+            className="flex-shrink-0 h-8 w-8 flex items-center justify-center rounded-full bg-black/5 hover:bg-black/10 transition-colors duration-200"
+          >
+            <X className="h-4 w-4 text-black/60" />
+          </button>
         </div>
-      </div>
-      <input type="file" ref={updateFileInputRef} className="hidden" onChange={handleFileUpdateSelected} />
-    </aside>
+
+        <div className="flex-1 overflow-y-auto px-6 pt-6 pb-6">
+          <div className="space-y-3 mb-8">
+            <div className="flex items-center justify-between py-3 border-b border-black/[0.08]">
+              <div className="flex items-center gap-3">
+                <CalendarDays className="h-4 w-4 text-black/40" />
+                <span className="text-[15px] text-black/60">订单日期</span>
+              </div>
+              <span className="text-[15px] font-medium text-black">{task.orderDate}</span>
+            </div>
+            {task.notes && (
+              <div className="py-3 border-b border-black/[0.08]">
+                <div className="flex items-center gap-3 mb-2">
+                  <MessageSquare className="h-4 w-4 text-black/40" />
+                  <span className="text-[15px] text-black/60">备注</span>
+                </div>
+                <p className="text-[15px] text-black leading-relaxed ml-7">{task.notes}</p>
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-3">
+            <button
+              onClick={handleDownloadAndOpen}
+              disabled={isDownloading}
+              className="w-full flex items-center gap-4 p-4 bg-green-500/8 hover:bg-green-500/12 rounded-2xl transition-all duration-200 group disabled:opacity-60 disabled:cursor-wait"
+            >
+              <div className="flex items-center justify-center h-10 w-10 rounded-full bg-green-500/15 group-hover:bg-green-500/20 transition-colors duration-200">
+                {isDownloading ? (
+                  <svg className="h-5 w-5 text-green-600 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <circle cx="12" cy="12" r="10" opacity="0.25" />
+                    <path d="M22 12a10 10 0 0 1-10 10" />
+                  </svg>
+                ) : (
+                  <Folder className="h-5 w-5 text-green-600" />
+                )}
+              </div>
+              <div className="flex-1 text-left">
+                <p className="text-[15px] font-medium text-black">
+                  {isDownloading ? "正在下载..." : "打开文件夹"}
+                </p>
+                <p className="text-[13px] text-black/50">
+                  {isDownloading ? "文件将保存在您的下载目录" : "快速获取所有项目文件"}
+                </p>
+              </div>
+            </button>
+
+            <button
+              onClick={() => setShowMetadata(true)}
+              className="w-full flex items-center gap-4 p-4 bg-black/5 hover:bg-black/10 rounded-2xl transition-all duration-200"
+            >
+              <div className="flex items-center justify-center h-10 w-10 rounded-full bg-black/10">
+                <FileCode className="h-5 w-5 text-black/70" />
+              </div>
+              <div className="flex-1 text-left">
+                <p className="text-[15px] font-medium text-black">查看元数据</p>
+                <p className="text-[13px] text-black/50">显示此任务的原始记录</p>
+              </div>
+            </button>
+          </div>
+        </div>
+      </aside>
+
+      <Dialog open={showMetadata} onOpenChange={setShowMetadata}>
+        <DialogContent className="max-w-xl" showCloseButton>
+          <DialogHeader>
+            <DialogTitle>任务元数据</DialogTitle>
+          </DialogHeader>
+          <pre className="mt-4 text-sm bg-black/5 rounded-md p-4 whitespace-pre-wrap overflow-x-auto">
+{JSON.stringify(task, null, 2)}
+          </pre>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- simplify the drawer UI now that file sync handles uploads
- add a button to open the task's raw metadata in a dialog

## Testing
- `npm install` *(fails: network access required)*
- `npm run lint` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_687a9f50c588832d8235cf8e83706a1e