### PR TITLE
Adjust workflow columns and YNMX ID

### DIFF
--- a/taintedpaint/components/SearchDialog.tsx
+++ b/taintedpaint/components/SearchDialog.tsx
@@ -152,7 +152,7 @@ export default function SearchDialog({ isOpen, onClose, onTaskSelect }: SearchDi
                   </div>
                   <div className="flex-1 min-w-0">
                     <h3 className="text-sm font-semibold text-gray-800 truncate">
-                      {['approval', 'production'].includes(task.columnId)
+                      {['sheet', 'approval', 'program', 'ship', 'archive2'].includes(task.columnId)
                         ? task.ynmxId || `${task.customerName} - ${task.representative}`
                         : `${task.customerName} - ${task.representative}`}
                     </h3>

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -61,19 +61,12 @@ export default function KanbanBoard() {
 
   const getNextYnmxId = useCallback(() => {
     const today = new Date().toISOString().slice(0, 10);
-    const prefix = `YNMX-${today}-`;
-    let max = 0;
-    Object.values(tasks).forEach((t) => {
-      if (t.ynmxId && t.ynmxId.startsWith(prefix)) {
-        const num = parseInt(t.ynmxId.slice(prefix.length), 10);
-        if (!isNaN(num) && num > max) max = num;
-      }
-    });
-    return prefix + String(max + 1).padStart(3, '0');
-  }, [tasks]);
+    const random = Math.floor(1000 + Math.random() * 9000);
+    return `YNMX-${today}-${random}`;
+  }, []);
 
   const getTaskDisplayName = (task: Task) => {
-    if (['approval', 'production'].includes(task.columnId)) {
+    if (['sheet', 'approval', 'program', 'ship', 'archive2'].includes(task.columnId)) {
       return task.ynmxId || `${task.customerName} - ${task.representative}`;
     }
     return `${task.customerName} - ${task.representative}`;
@@ -138,7 +131,7 @@ export default function KanbanBoard() {
     if (!draggedTask || draggedTask.columnId === targetColumnId) return;
 
     let updatedTask: Task = { ...draggedTask, columnId: targetColumnId };
-    if (['approval', 'production'].includes(targetColumnId) && !draggedTask.ynmxId) {
+    if (targetColumnId === 'sheet' && !draggedTask.ynmxId) {
       updatedTask = { ...updatedTask, ynmxId: getNextYnmxId() };
     }
 
@@ -200,7 +193,7 @@ export default function KanbanBoard() {
   const allTasksForSearch = useMemo(() => Object.values(tasks), [tasks]);
   const visibleColumns = useMemo(() => {
     if (viewMode === 'production') {
-      return columns.filter(c => ['approval', 'production'].includes(c.id))
+      return columns.filter(c => ['approval', 'program', 'ship', 'archive2'].includes(c.id))
     }
     return columns
   }, [viewMode, columns])

--- a/taintedpaint/lib/baseColumns.ts
+++ b/taintedpaint/lib/baseColumns.ts
@@ -12,5 +12,7 @@ export const baseColumns: Column[] = [
   { id: "archive",     title: "存档",   taskIds: [] },
   { id: "sheet",       title: "制单",   taskIds: [] },
   { id: "approval",    title: "审批",   taskIds: [] },
-  { id: "production",  title: "投产",   taskIds: [] }
+  { id: "program",     title: "编程",   taskIds: [] },
+  { id: "ship",        title: "出货",   taskIds: [] },
+  { id: "archive2",    title: "存档2",  taskIds: [] }
 ];

--- a/taintedpaint/public/storage/metadata.json
+++ b/taintedpaint/public/storage/metadata.json
@@ -132,8 +132,18 @@
       "taskIds": []
     },
     {
-      "id": "production",
-      "title": "投产",
+      "id": "program",
+      "title": "编程",
+      "taskIds": []
+    },
+    {
+      "id": "ship",
+      "title": "出货",
+      "taskIds": []
+    },
+    {
+      "id": "archive2",
+      "title": "存档2",
       "taskIds": []
     }
   ]


### PR DESCRIPTION
## Summary
- update default Kanban columns (remove 投产 and add 编程/出货/存档2)
- generate YNMX id with current date and random number when moved to 制单
- display YNMX id after 制单 column
- show new columns in production view and search results
- update sample board data

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aab398d6c832d96d523fe45f1032a