### PR TITLE
Rename archive2 column

### DIFF
--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -173,7 +173,7 @@ export default function KanbanBoard() {
   const handleTaskClick = (task: Task, e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    if (task.columnId === "archive") return;
+    if (task.columnId === "archive" || task.columnId === "archive2") return;
 
     const column = columns.find((c) => c.id === task.columnId);
     setSelectedTaskColumnTitle(column ? column.title : null);
@@ -259,7 +259,7 @@ export default function KanbanBoard() {
           {visibleColumns.map((column) => {
             const columnTasks = column.taskIds.map(id => tasks[id]).filter(Boolean);
 
-            return column.id === "archive" ? (
+            return ['archive', 'archive2'].includes(column.id) ? (
               <div
                 key={column.id}
                 onDragOver={handleDragOver}

--- a/taintedpaint/lib/baseColumns.ts
+++ b/taintedpaint/lib/baseColumns.ts
@@ -14,5 +14,5 @@ export const baseColumns: Column[] = [
   { id: "approval",    title: "审批",   taskIds: [] },
   { id: "program",     title: "编程",   taskIds: [] },
   { id: "ship",        title: "出货",   taskIds: [] },
-  { id: "archive2",    title: "存档2",  taskIds: [] }
+  { id: "archive2",    title: "存档",   taskIds: [] }
 ];

--- a/taintedpaint/public/storage/metadata.json
+++ b/taintedpaint/public/storage/metadata.json
@@ -143,7 +143,7 @@
     },
     {
       "id": "archive2",
-      "title": "存档2",
+      "title": "存档",
       "taskIds": []
     }
   ]


### PR DESCRIPTION
## Summary
- rename archive2 column to `存档`
- render archive2 the same as the existing archive column

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*
- `npm test` in blackpaint *(fails: Missing script)*
- `npm run lint` in blackpaint *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_687aaef4d520832d9047b88f88054610