### PR TITLE
Improve file watching

### DIFF
--- a/blackpaint/package.json
+++ b/blackpaint/package.json
@@ -50,6 +50,7 @@
     "electron-squirrel-startup": "^1.0.1",
     "lucide-react": "^0.525.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "chokidar": "^3.6.0"
   }
 }


### PR DESCRIPTION
## Summary
- refactor sync.ts to use chokidar for file watching
- add chokidar dependency

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_687ab1520df0832dac5555cedeb3a67c