### PR TITLE
Update Electron API typing

### DIFF
--- a/taintedpaint/components/KanbanDrawer.tsx
+++ b/taintedpaint/components/KanbanDrawer.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import type { Task } from "@/types";
+import type { ElectronAPI } from "@/types/electron";
 import { useState, useCallback } from "react";
 import { X, CalendarDays, MessageSquare, Folder, FileCode } from "lucide-react";
 import {
@@ -29,7 +30,8 @@ export default function KanbanDrawer({
 
   const handleDownloadAndOpen = useCallback(async () => {
     if (!task) return;
-    if (!window.electronAPI) {
+    const electronAPI: ElectronAPI | undefined = window.electronAPI;
+    if (!electronAPI) {
       alert("此功能仅在桌面应用中可用。请下载桌面版以获得最佳体验。");
       return;
     }
@@ -43,7 +45,7 @@ export default function KanbanDrawer({
         return;
       }
       const folderName = task.ynmxId || `${task.customerName} - ${task.representative}`;
-      await window.electronAPI.downloadAndOpenTaskFolder(task.id, folderName, filesToDownload);
+      await electronAPI.downloadAndOpenTaskFolder(task.id, folderName, filesToDownload);
     } catch (err: any) {
       console.error("Download and open failed:", err);
       alert(`下载失败: ${err.message}`);

--- a/taintedpaint/types/electron.d.ts
+++ b/taintedpaint/types/electron.d.ts
@@ -1,8 +1,9 @@
 // types/electron.d.ts (in your Next.js project)
 
 // This interface must match the object exposed in preload.ts
-interface ElectronAPI {
+export interface ElectronAPI {
   downloadAndOpenTaskFolder: (
+    taskId: string,
     folderName: string,
     // This signature must match the one in preload.ts
     filesToDownload: { filename: string, relativePath: string, url: string }[]


### PR DESCRIPTION
## Summary
- revise `downloadAndOpenTaskFolder` interface to include task id
- import and utilize the type in `KanbanDrawer`

## Testing
- `npx tsc -p taintedpaint/tsconfig.json` *(fails: cannot find modules)*
- `npx tsc -p blackpaint/tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_687ab6a5f3e8832db64a9dc3e167a70c