### PR TITLE
Validate upload path

### DIFF
--- a/taintedpaint/app/api/jobs/[taskId]/upload/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/upload/route.ts
@@ -38,6 +38,11 @@ export async function POST(
     for (let i = 0; i < files.length; i++) {
       const file = files[i];
       const relPath = paths[i] || file.name;
+
+      if (path.isAbsolute(relPath)) {
+        return NextResponse.json({ error: "Paths must be relative" }, { status: 400 });
+      }
+
       const safeRelPath = path.normalize(relPath).replace(/^(\.\.[\/\\])+/, '');
       const filePath = path.join(taskDirectoryPath, safeRelPath);
       await fs.mkdir(path.dirname(filePath), { recursive: true });


### PR DESCRIPTION
## Summary
- ensure uploaded paths are relative in the job upload handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b085c0f38832dbe8bf1a153ddc854