### PR TITLE
Fix path conversion for sync

### DIFF
--- a/blackpaint/src/sync.ts
+++ b/blackpaint/src/sync.ts
@@ -71,7 +71,8 @@ export function startBidirectionalSync(taskId: string, localRoot: string) {
     ignoreInitial: true,
   });
 
-  const toRel = (full: string) => full.replace(localRoot + path.sep, '').replace(/\\/g, '/');
+  const toRel = (fullPath: string) =>
+    path.relative(localRoot, fullPath).replace(/\\/g, '/');
 
   watcher
     .on('add', async (filePath) => {


### PR DESCRIPTION
## Summary
- ensure paths are normalized using `path.relative`

## Testing
- `npm test` in `taintedpaint`
- `npm run lint` *(fails: `next` not found)*
- `npm test` in `blackpaint` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_687b08b440e0832dbfcadfed6f9b18f5