### PR TITLE
Add network error handling in sync utilities

### DIFF
--- a/blackpaint/src/sync.ts
+++ b/blackpaint/src/sync.ts
@@ -23,18 +23,26 @@ async function uploadFile(taskId: string, localRoot: string, relPath: string) {
   form.append('files', new Blob([file]));
   form.append('paths', relPath);
 
-  await fetch(`${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/api/jobs/${taskId}/upload`, {
-    method: 'POST',
-    body: form,
-  });
+  try {
+    await fetch(`${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/api/jobs/${taskId}/upload`, {
+      method: 'POST',
+      body: form,
+    });
+  } catch (err) {
+    console.error('Failed to upload file', err);
+  }
 }
 
 async function deleteFile(taskId: string, relPath: string) {
-  await fetch(`${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/api/jobs/${taskId}/delete-file`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ filename: relPath }),
-  });
+  try {
+    await fetch(`${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/api/jobs/${taskId}/delete-file`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ filename: relPath }),
+    });
+  } catch (err) {
+    console.error('Failed to delete file', err);
+  }
 }
 
 async function pullFromServer(taskId: string, localRoot: string) {


### PR DESCRIPTION
## Summary
- catch and log network failures in file sync helpers

## Testing
- `npm run lint` *(fails: couldn't find ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_687b09463ec8832d9434e1260725470a