### PR TITLE
Improve board data concurrency and sync

### DIFF
--- a/taintedpaint/app/api/jobs/[taskId]/delete-file/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/delete-file/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { promises as fs } from "fs";
 import path from "path";
 import type { BoardData } from "@/types";
-import { writeJsonAtomic } from "@/lib/fileUtils";
+import { updateBoardData } from "@/lib/boardDataStore";
 import { sanitizeRelativePath } from "@/lib/pathUtils.mjs";
 
 // --- Path Definitions ---
@@ -48,25 +48,19 @@ export async function POST(
       console.warn(`File to be deleted not found on disk, proceeding to update metadata: ${filePath}`);
     }
 
-    // 2. Read metadata
-    const rawMeta = await fs.readFile(META_FILE, "utf-8");
-    const boardData: BoardData = JSON.parse(rawMeta);
+    let updatedTask: BoardData["tasks"][string] | undefined;
+    await updateBoardData(async (boardData) => {
+      const taskToUpdate = boardData.tasks[taskId];
+      if (!taskToUpdate) throw new Error("Task not found in metadata");
 
-    const taskToUpdate = boardData.tasks[taskId];
-    if (!taskToUpdate) {
-      return NextResponse.json({ error: "Task not found in metadata" }, { status: 404 });
-    }
+      if (taskToUpdate.files) {
+        taskToUpdate.files = taskToUpdate.files.filter((f) => f !== safeFilename);
+      }
 
-    // 3. IMPORTANT: Update metadata by filtering the existing array to preserve order
-    if (taskToUpdate.files) {
-      taskToUpdate.files = taskToUpdate.files.filter(f => f !== safeFilename);
-    }
+      updatedTask = taskToUpdate;
+    });
 
-    // 4. Write the updated metadata back
-    await writeJsonAtomic(META_FILE, boardData);
-
-    // 5. Return the fully updated task object to the client
-    return NextResponse.json(taskToUpdate);
+    return NextResponse.json(updatedTask);
 
   } catch (err) {
     console.error(`Failed to delete file for task ${taskId}:`, err);

--- a/taintedpaint/lib/boardDataStore.ts
+++ b/taintedpaint/lib/boardDataStore.ts
@@ -1,0 +1,56 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import { randomUUID } from 'crypto'
+import { baseColumns } from './baseColumns'
+import type { BoardData } from '@/types'
+
+const STORAGE_DIR = path.join(process.cwd(), 'public', 'storage')
+const META_FILE = path.join(STORAGE_DIR, 'metadata.json')
+const LOCK_FILE = META_FILE + '.lock'
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export async function readBoardData(): Promise<BoardData> {
+  try {
+    const raw = await fs.readFile(META_FILE, 'utf-8')
+    const data = JSON.parse(raw)
+    if (data.tasks && data.columns) return data
+    throw new Error('Invalid metadata format')
+  } catch {
+    return { tasks: {}, columns: baseColumns }
+  }
+}
+
+export async function updateBoardData(
+  updater: (data: BoardData) => void | Promise<void>
+): Promise<BoardData> {
+  // simple lock using a temp file
+  while (true) {
+    try {
+      const fd = await fs.open(LOCK_FILE, 'wx')
+      await fd.close()
+      break
+    } catch (err: any) {
+      if (err.code === 'EEXIST') {
+        await sleep(50)
+        continue
+      }
+      throw err
+    }
+  }
+
+  try {
+    const data = await readBoardData()
+    await updater(data)
+
+    const tempPath = `${META_FILE}.${randomUUID()}.tmp`
+    await fs.writeFile(tempPath, JSON.stringify(data, null, 2))
+    await fs.rename(tempPath, META_FILE)
+
+    return data
+  } finally {
+    await fs.unlink(LOCK_FILE).catch(() => {})
+  }
+}


### PR DESCRIPTION
## Summary
- add a small boardDataStore module with file locking
- use boardDataStore in all API routes that mutate metadata
- enhance sync to handle deletions and ignore changes triggered by pulls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cc2f29fa0832da4dd553cc87a4000