### PR TITLE
UI overhaul for kanban components

### DIFF
--- a/taintedpaint/components/CreateJobForm.tsx
+++ b/taintedpaint/components/CreateJobForm.tsx
@@ -87,7 +87,7 @@ export default function CreateJobForm({ onJobCreated }: CreateJobFormProps) {
   };
 
   return (
-    <div className="flex-shrink-0 w-72 bg-white flex flex-col p-4 gap-4 rounded-xl mx-2 my-4 shadow-sm border border-neutral-200/80">
+    <div className="flex-shrink-0 w-72 bg-white/90 backdrop-blur-sm flex flex-col p-4 gap-4 rounded-lg mx-2 my-4 shadow-sm border border-gray-200/80">
       <div className="flex items-center gap-2 px-1">
         <PlusCircle className="h-5 w-5 text-neutral-500" />
         <h2 className="text-base font-semibold text-neutral-800">新建任务</h2>
@@ -96,7 +96,7 @@ export default function CreateJobForm({ onJobCreated }: CreateJobFormProps) {
       <div className="w-full space-y-3">
         <label
           htmlFor="folderUpload"
-          className="flex items-center justify-between w-full rounded-lg bg-neutral-100 hover:bg-neutral-200/70 transition-colors cursor-pointer px-3 py-2.5"
+          className="flex items-center justify-between w-full rounded-md bg-gray-100 hover:bg-gray-200 transition-colors cursor-pointer px-3 py-2.5"
         >
           <div className="flex items-center gap-2 truncate">
             <Folder className="h-4 w-4 text-neutral-400 flex-shrink-0" />
@@ -124,32 +124,32 @@ export default function CreateJobForm({ onJobCreated }: CreateJobFormProps) {
           placeholder="客户"
           value={customerName}
           onChange={(e) => setCustomerName(e.target.value)}
-          className="text-sm bg-neutral-100 border-none rounded-lg px-3 py-2.5 h-auto focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 placeholder:text-neutral-500"
+          className="text-sm bg-gray-100 border-none rounded-md px-3 py-2.5 h-auto focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 placeholder:text-gray-500"
         />
         <Input
           placeholder="负责人"
           value={representative}
           onChange={(e) => setRepresentative(e.target.value)}
-          className="text-sm bg-neutral-100 border-none rounded-lg px-3 py-2.5 h-auto focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 placeholder:text-neutral-500"
+          className="text-sm bg-gray-100 border-none rounded-md px-3 py-2.5 h-auto focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 placeholder:text-gray-500"
         />
         <Input
           type="text"
           placeholder="日期"
           value={orderDate}
           onChange={(e) => setOrderDate(e.target.value)}
-          className="text-sm bg-neutral-100 border-none rounded-lg px-3 py-2.5 h-auto focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 placeholder:text-neutral-500"
+          className="text-sm bg-gray-100 border-none rounded-md px-3 py-2.5 h-auto focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 placeholder:text-gray-500"
         />
         <Input
           placeholder="备注"
           value={notes}
           onChange={(e) => setNotes(e.target.value)}
-          className="text-sm bg-neutral-100 border-none rounded-lg px-3 py-2.5 h-auto focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 placeholder:text-neutral-500"
+          className="text-sm bg-gray-100 border-none rounded-md px-3 py-2.5 h-auto focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 placeholder:text-gray-500"
         />
       </div>
 
       <Button
         onClick={handleCreateJob}
-        className="w-full bg-neutral-800 hover:bg-neutral-900 text-white font-semibold py-2.5 rounded-lg transition-all duration-200 shadow-sm hover:shadow-md focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:bg-neutral-800/40 disabled:shadow-none disabled:cursor-not-allowed"
+        className="w-full bg-gray-900 hover:bg-black text-white font-semibold py-2.5 rounded-md transition-all duration-200 shadow-sm hover:shadow-md focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:bg-gray-900/40 disabled:shadow-none disabled:cursor-not-allowed"
         disabled={
           !selectedFiles ||
           selectedFiles.length === 0 ||

--- a/taintedpaint/components/KanbanDrawer.tsx
+++ b/taintedpaint/components/KanbanDrawer.tsx
@@ -63,7 +63,7 @@ export default function KanbanDrawer({
   return (
     <>
       <aside
-        className={`fixed inset-y-0 right-0 w-[400px] bg-white/95 backdrop-blur-xl border-l border-black/[0.08] transition-transform duration-400 ease-[cubic-bezier(0.32,0.72,0,1)] z-50 flex flex-col ${isOpen ? "translate-x-0 shadow-[0_8px_64px_0_rgba(0,0,0,0.25)]" : "translate-x-full"}`}
+        className={`fixed inset-y-0 right-0 w-[400px] bg-white/90 backdrop-blur-md border-l border-gray-200/80 transition-transform duration-400 ease-[cubic-bezier(0.32,0.72,0,1)] z-50 flex flex-col ${isOpen ? "translate-x-0 shadow-[0_8px_64px_0_rgba(0,0,0,0.25)]" : "translate-x-full"}`}
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex-shrink-0 px-6 pt-6 pb-0 flex items-start justify-between">
@@ -87,7 +87,7 @@ export default function KanbanDrawer({
           </div>
           <button
             onClick={onClose}
-            className="flex-shrink-0 h-8 w-8 flex items-center justify-center rounded-full bg-black/5 hover:bg-black/10 transition-colors duration-200"
+            className="flex-shrink-0 h-8 w-8 flex items-center justify-center rounded-md bg-black/5 hover:bg-black/10 transition-colors duration-200"
           >
             <X className="h-4 w-4 text-black/60" />
           </button>
@@ -117,9 +117,9 @@ export default function KanbanDrawer({
             <button
               onClick={handleDownloadAndOpen}
               disabled={isDownloading}
-              className="w-full flex items-center gap-4 p-4 bg-green-500/8 hover:bg-green-500/12 rounded-2xl transition-all duration-200 group disabled:opacity-60 disabled:cursor-wait"
+              className="w-full flex items-center gap-4 p-4 bg-green-500/8 hover:bg-green-500/12 rounded-lg transition-all duration-200 group disabled:opacity-60 disabled:cursor-wait"
             >
-              <div className="flex items-center justify-center h-10 w-10 rounded-full bg-green-500/15 group-hover:bg-green-500/20 transition-colors duration-200">
+              <div className="flex items-center justify-center h-10 w-10 rounded bg-green-500/15 group-hover:bg-green-500/20 transition-colors duration-200">
                 {isDownloading ? (
                   <svg className="h-5 w-5 text-green-600 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                     <circle cx="12" cy="12" r="10" opacity="0.25" />
@@ -141,9 +141,9 @@ export default function KanbanDrawer({
 
             <button
               onClick={() => setShowMetadata(true)}
-              className="w-full flex items-center gap-4 p-4 bg-black/5 hover:bg-black/10 rounded-2xl transition-all duration-200"
+              className="w-full flex items-center gap-4 p-4 bg-black/5 hover:bg-black/10 rounded-lg transition-all duration-200"
             >
-              <div className="flex items-center justify-center h-10 w-10 rounded-full bg-black/10">
+              <div className="flex items-center justify-center h-10 w-10 rounded bg-black/10">
                 <FileCode className="h-5 w-5 text-black/70" />
               </div>
               <div className="flex-1 text-left">

--- a/taintedpaint/components/SearchDialog.tsx
+++ b/taintedpaint/components/SearchDialog.tsx
@@ -90,12 +90,12 @@ export default function SearchDialog({ isOpen, onClose, onTaskSelect }: SearchDi
 
   return createPortal(
     <div
-      className="fixed inset-0 bg-black/10 backdrop-blur-sm z-50 flex justify-center items-start"
+      className="fixed inset-0 bg-black/20 backdrop-blur-sm z-50 flex justify-center items-start"
       onClick={onClose}
     >
       <div
-        className="w-[95vw] max-w-2xl mt-[20vh] bg-white/75 backdrop-blur-2xl border border-gray-200/80 
-                   rounded-2xl shadow-2xl flex flex-col overflow-hidden
+        className="w-[95vw] max-w-2xl mt-[20vh] bg-white/90 backdrop-blur-md border border-gray-200/70
+                   rounded-xl shadow-xl flex flex-col overflow-hidden
                    animate-in fade-in-0 zoom-in-95 duration-300"
         onClick={(e) => e.stopPropagation()}
         role="dialog"
@@ -113,7 +113,7 @@ export default function SearchDialog({ isOpen, onClose, onTaskSelect }: SearchDi
           {isLoading && <Loader2 className="h-5 w-5 text-gray-500 animate-spin" />}
           <button
             onClick={onClose}
-            className="p-1.5 rounded-full text-gray-500 hover:bg-black/10 transition-colors"
+            className="p-1.5 rounded-full text-gray-500 hover:bg-black/20 transition-colors"
             aria-label="关闭搜索"
           >
             <X className="h-4 w-4" />
@@ -141,13 +141,13 @@ export default function SearchDialog({ isOpen, onClose, onTaskSelect }: SearchDi
               {results.map(({ task, columnTitle }) => (
                 <div
                   key={task.id}
-                  className="flex items-center gap-4 p-3 rounded-lg cursor-pointer transition-colors hover:bg-black/5"
+                  className="flex items-center gap-4 p-3 rounded-lg cursor-pointer transition-colors hover:bg-black/10"
                   onClick={() => handleSelectTask(task)}
                   role="button"
                   tabIndex={0}
                   onKeyDown={(e) => e.key === "Enter" && handleSelectTask(task)}
                 >
-                  <div className="flex-shrink-0 bg-black/5 p-2 rounded-md">
+                  <div className="flex-shrink-0 bg-gray-100 p-2 rounded-md">
                     <FileText className="h-5 w-5 text-gray-600" />
                   </div>
                   <div className="flex-1 min-w-0">

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -16,6 +16,18 @@ export default function KanbanBoard() {
   const [viewMode, setViewMode] = useState<'business' | 'production'>('business')
   const [draggedTask, setDraggedTask] = useState<Task | null>(null)
   const [dragOverColumn, setDragOverColumn] = useState<string | null>(null)
+
+  const columnColors: Record<string, string> = {
+    create: 'bg-blue-500',
+    quote: 'bg-purple-500',
+    send: 'bg-teal-500',
+    sheet: 'bg-orange-500',
+    approval: 'bg-yellow-500',
+    program: 'bg-indigo-500',
+    ship: 'bg-green-500',
+    archive: 'bg-gray-400',
+    archive2: 'bg-gray-400',
+  }
   const [selectedTask, setSelectedTask] = useState<Task | null>(null)
   const [selectedTaskColumnTitle, setSelectedTaskColumnTitle] = useState<string | null>(null)
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
@@ -199,8 +211,8 @@ export default function KanbanBoard() {
   }, [viewMode, columns])
 
   return (
-    <div className="h-screen w-full flex flex-col bg-gray-50/50">
-      <header className="px-6 py-4 bg-white/80 backdrop-blur-xl sticky top-0 z-30 border-b-2 border-gray-200/60">
+    <div className="min-h-screen w-full flex flex-col bg-white text-gray-900 font-sans">
+      <header className="px-6 py-4 bg-white/90 backdrop-blur-sm sticky top-0 z-30 border-b border-gray-200/80">
         <div className="flex items-center justify-between">
           <div className="flex items-baseline gap-2">
             <h1 className="text-xl font-medium text-gray-900 tracking-tight">Eldaline</h1>
@@ -208,16 +220,16 @@ export default function KanbanBoard() {
           </div>
 
           <div className="flex items-center gap-4">
-            <div className="flex bg-gray-100/60 backdrop-blur-sm border border-gray-200/60 rounded-full p-0.5">
+            <div className="flex bg-gray-100/50 backdrop-blur-sm border border-gray-200/60 rounded-md p-0.5">
               <button
                 onClick={() => setViewMode('business')}
-                className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${viewMode === 'business' ? 'bg-white shadow text-gray-900' : 'text-gray-600 hover:text-gray-800'}`}
+                className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${viewMode === 'business' ? 'bg-white shadow text-gray-900' : 'text-gray-600 hover:text-gray-800'}`}
               >
                 商务
               </button>
               <button
                 onClick={() => setViewMode('production')}
-                className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${viewMode === 'production' ? 'bg-white shadow text-gray-900' : 'text-gray-600 hover:text-gray-800'}`}
+                className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${viewMode === 'production' ? 'bg-white shadow text-gray-900' : 'text-gray-600 hover:text-gray-800'}`}
               >
                 生产
               </button>
@@ -228,7 +240,7 @@ export default function KanbanBoard() {
               className="group relative flex items-center justify-center gap-2.5 px-4 py-2.5
                         bg-gray-100/60 backdrop-blur-sm
                         border border-gray-200/60 hover:border-gray-300/80
-                        rounded-full shadow-sm hover:shadow-md
+                        rounded-md shadow-sm hover:shadow-md
                         transform-gpu transition-all duration-200 ease-out
                         hover:bg-white/80 active:scale-[0.96]"
             >
@@ -266,11 +278,11 @@ export default function KanbanBoard() {
                 onDragEnter={() => handleDragEnter(column.id)}
                 onDragLeave={handleDragLeave}
                 onDrop={(e) => handleDrop(e, column.id)}
-                className={`flex-shrink-0 w-72 flex flex-col rounded-xl transition-colors duration-200 ${
-                  dragOverColumn === column.id ? "bg-blue-100/50" : "bg-gray-100/80"
+                className={`flex-shrink-0 w-72 flex flex-col rounded-lg transition-colors duration-200 ${
+                  dragOverColumn === column.id ? 'bg-blue-50/50' : 'bg-white/70'
                 }`}
               >
-                <div className="p-4 border-b border-gray-200/80 sticky top-0 z-20 bg-gray-100/80 backdrop-blur-md rounded-t-xl">
+                <div className="p-4 border-b border-gray-200/80 sticky top-0 z-20 bg-white/80 backdrop-blur-sm rounded-t-lg">
                   <div className="flex items-center gap-2">
                     <Archive className="h-4 w-4 text-gray-600" strokeWidth={1.5} />
                     <h2 className="text-base font-semibold text-gray-800">{column.title}</h2>
@@ -303,20 +315,16 @@ export default function KanbanBoard() {
                           draggable
                           onDragStart={() => handleDragStart(task)}
                           onClick={(e) => handleTaskClick(task, e)}
-                          className="p-3 cursor-pointer hover:shadow-lg hover:-translate-y-px transform transition-all duration-200 border border-gray-200/60 bg-white/60 group rounded-xl shadow-sm opacity-75 hover:opacity-100"
+                          className="relative p-3 cursor-pointer hover:shadow-md hover:-translate-y-px transform transition-all duration-200 border border-gray-200 bg-white group rounded-lg shadow-sm"
                         >
-                          <div className="flex items-start gap-2">
-                            <div className="flex-1 min-w-0">
-                               <div
-                                className={`p-1 -m-1 rounded-md transition-colors duration-500
-                                  ${highlightedTaskId === task.id ? 'bg-yellow-300/80' : 'bg-transparent'}`
-                                }
-                              >
-                                <h3 className="text-sm font-medium text-gray-700 mb-1.5 leading-tight group-hover:text-gray-900 transition-colors">
-                                  {getTaskDisplayName(task)}
-                                </h3>
-                                <p className="text-xs text-gray-500 leading-relaxed">{task.orderDate}</p>
-                              </div>
+                          <div className={`absolute left-0 top-0 h-full w-1 rounded-l ${columnColors[task.columnId]}`} />
+                          <div className="pl-4 pr-2">
+                            <div className={`p-1 -m-1 rounded-md transition-colors duration-500 ${highlightedTaskId === task.id ? 'bg-yellow-200/70' : 'bg-transparent'}`}
+                            >
+                              <h3 className="text-sm font-medium text-gray-800 mb-1.5 leading-tight group-hover:text-gray-900 transition-colors">
+                                {getTaskDisplayName(task)}
+                              </h3>
+                              <p className="text-xs text-gray-500 leading-relaxed">{task.orderDate}</p>
                             </div>
                           </div>
                         </Card>
@@ -332,11 +340,11 @@ export default function KanbanBoard() {
                 onDragEnter={() => handleDragEnter(column.id)}
                 onDragLeave={handleDragLeave}
                 onDrop={(e) => handleDrop(e, column.id)}
-                className={`flex-shrink-0 w-72 flex flex-col rounded-xl border border-gray-200/75 shadow-sm hover:shadow-md transform-gpu transition-all duration-300 ${
-                  dragOverColumn === column.id ? "bg-blue-100/50" : "bg-gray-100/80"
+                className={`flex-shrink-0 w-72 flex flex-col rounded-lg border border-gray-200/80 shadow-sm hover:shadow-md transform-gpu transition-all duration-300 bg-white/70 ${
+                  dragOverColumn === column.id ? 'bg-blue-50/50' : ''
                 }`}
               >
-                <div className="p-4 border-b border-gray-200/80 sticky top-0 z-20 bg-gray-100/80 backdrop-blur-md rounded-t-xl">
+                <div className="p-4 border-b border-gray-200/80 sticky top-0 z-20 bg-white/80 backdrop-blur-sm rounded-t-lg">
                   <div className="flex items-center gap-2">
                     <h2 className="text-base font-semibold text-gray-800">{column.title}</h2>
                     <span className="text-xs font-medium text-gray-500 bg-gray-200/80 px-2 py-0.5 rounded-full min-w-[20px] text-center">
@@ -356,17 +364,17 @@ export default function KanbanBoard() {
                       draggable
                       onDragStart={() => handleDragStart(task)}
                       onClick={(e) => handleTaskClick(task, e)}
-                      className="p-3 cursor-pointer hover:shadow-lg hover:-translate-y-px transform transition-all duration-200 border border-gray-200/60 bg-white group rounded-xl shadow-sm"
+                      className="relative p-3 cursor-pointer hover:shadow-md hover:-translate-y-px transform transition-all duration-200 border border-gray-200 bg-white group rounded-lg shadow-sm"
                     >
-                      <div
-                        className={`p-1 -m-1 rounded-md transition-colors duration-500
-                          ${highlightedTaskId === task.id ? 'bg-yellow-300/80' : 'bg-transparent'}`
-                        }
-                      >
-                        <h3 className="text-sm font-medium text-gray-900 mb-1.5 leading-tight group-hover:text-blue-700 transition-colors">
-                          {getTaskDisplayName(task)}
-                        </h3>
-                        <p className="text-xs text-gray-600 leading-relaxed">{task.orderDate}</p>
+                      <div className={`absolute left-0 top-0 h-full w-1 rounded-l ${columnColors[task.columnId]}`} />
+                      <div className="pl-4 pr-2">
+                        <div className={`p-1 -m-1 rounded-md transition-colors duration-500 ${highlightedTaskId === task.id ? 'bg-yellow-200/70' : 'bg-transparent'}`}
+                        >
+                          <h3 className="text-sm font-medium text-gray-800 mb-1.5 leading-tight group-hover:text-gray-900 transition-colors">
+                            {getTaskDisplayName(task)}
+                          </h3>
+                          <p className="text-xs text-gray-500 leading-relaxed">{task.orderDate}</p>
+                        </div>
                       </div>
                     </Card>
                   ))}


### PR DESCRIPTION
## Summary
- modernize `CreateJobForm` styling
- update drawer and search dialog visuals
- adjust kanban board layout and cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cfe418464832d998baee02dfd07c8