### PR TITLE
Add archive overview integration

### DIFF
--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -5,7 +5,8 @@ import type { Task, Column, BoardData } from "@/types"
 import { useState, useEffect, useCallback, useMemo, useRef } from "react"
 import CreateJobForm from "@/components/CreateJobForm"
 import { Card } from "@/components/ui/card"
-import { Archive, Search } from "lucide-react"
+import { Archive, Search, LayoutGrid } from "lucide-react"
+import Link from "next/link"
 import { baseColumns, START_COLUMN_ID } from "@/lib/baseColumns"
 import KanbanDrawer from "@/components/KanbanDrawer"
 import SearchDialog from "@/components/SearchDialog"
@@ -253,6 +254,10 @@ export default function KanbanBoard() {
                 <kbd className="px-1.5 py-0.5 text-xs font-medium text-gray-400 bg-gray-200/60 rounded border border-gray-300/40">K</kbd>
               </div>
             </button>
+              <Link href="/preview" className="group relative flex items-center justify-center gap-2.5 px-4 py-2.5 bg-gray-100/60 backdrop-blur-sm border border-gray-200/60 hover:border-gray-300/80 rounded-md shadow-sm hover:shadow-md transform-gpu transition-all duration-200 ease-out hover:bg-white/80 active:scale-[0.96]">
+                <LayoutGrid className="h-4 w-4 text-gray-500 group-hover:text-gray-700 transition-colors duration-200" strokeWidth={2} />
+                <span className="text-sm font-medium text-gray-600 group-hover:text-gray-800 transition-colors duration-200">总揽</span>
+              </Link>
           </div>
         </div>
       </header>


### PR DESCRIPTION
## Summary
- hook up `/preview` to board data
- add Apple-style blocker fields for missing info
- allow opening Kanban drawer from overview
- link to overview in board header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d02ab5718832dba5d6c119648720f