### PR TITLE
Improve holistic page navigation

### DIFF
--- a/taintedpaint/app/holistic/page.tsx
+++ b/taintedpaint/app/holistic/page.tsx
@@ -10,6 +10,8 @@ import { useState, useMemo, useEffect } from 'react';
 import type { Task, Column, BoardData } from '@/types';
 import { baseColumns } from '@/lib/baseColumns';
 import KanbanDrawer from '@/components/KanbanDrawer';
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
 
 // ─── Utilities ────────────────────────────────────────────────────────────────
 // 超轻量 mock 版 dayjs，只实现本例需要的 format / valueOf
@@ -133,7 +135,12 @@ export default function ArchivePage() {
       <div className="max-w-6xl mx-auto px-6 py-8">
         {/* ── Header & Filters (吸顶) ───────────────────────────────── */}
         <div className="sticky top-0 z-10 bg-white/95 backdrop-blur-sm pb-6 mb-8">
-          <h1 className="text-3xl font-light mb-2">档案库</h1>
+          <div className="flex items-center gap-3 mb-2">
+            <Link href="/" aria-label="返回看板" className="text-gray-500 hover:text-gray-800">
+              <ArrowLeft className="w-5 h-5" />
+            </Link>
+            <h1 className="text-3xl font-light">档案库</h1>
+          </div>
 
           {/* ── Metrics 指标栏 ─────────────────────────────── */}
           <div className="text-sm text-gray-600 mb-6 space-x-8">
@@ -263,10 +270,24 @@ function JobCard({ job, onClick }: { job: Job; onClick: () => void }) {
           {job.value ? (
             <span className="font-medium">¥{(job.value / 1000).toFixed(0)}k</span>
           ) : (
-            <BlockedField />
+            <span className="inline-flex items-center gap-0.5 font-medium">
+              ¥<BlockedField />k
+            </span>
           )}
-          {job.qty ? <span>{job.qty}件</span> : <BlockedField />}
-          {job.axis ? <span>{job.axis}</span> : <BlockedField />}
+          {job.qty ? (
+            <span>{job.qty}件</span>
+          ) : (
+            <span className="inline-flex items-center">
+              <BlockedField />件
+            </span>
+          )}
+          {job.axis ? (
+            <span>{job.axis}</span>
+          ) : (
+            <span className="inline-flex items-center">
+              <BlockedField />轴
+            </span>
+          )}
         </div>
       </div>
     </div>

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -254,7 +254,7 @@ export default function KanbanBoard() {
                 <kbd className="px-1.5 py-0.5 text-xs font-medium text-gray-400 bg-gray-200/60 rounded border border-gray-300/40">K</kbd>
               </div>
             </button>
-              <Link href="/preview" className="group relative flex items-center justify-center gap-2.5 px-4 py-2.5 bg-gray-100/60 backdrop-blur-sm border border-gray-200/60 hover:border-gray-300/80 rounded-md shadow-sm hover:shadow-md transform-gpu transition-all duration-200 ease-out hover:bg-white/80 active:scale-[0.96]">
+              <Link href="/holistic" className="group relative flex items-center justify-center gap-2.5 px-4 py-2.5 bg-gray-100/60 backdrop-blur-sm border border-gray-200/60 hover:border-gray-300/80 rounded-md shadow-sm hover:shadow-md transform-gpu transition-all duration-200 ease-out hover:bg-white/80 active:scale-[0.96]">
                 <LayoutGrid className="h-4 w-4 text-gray-500 group-hover:text-gray-700 transition-colors duration-200" strokeWidth={2} />
                 <span className="text-sm font-medium text-gray-600 group-hover:text-gray-800 transition-colors duration-200">总揽</span>
               </Link>


### PR DESCRIPTION
## Summary
- rename preview route to **holistic**
- add back link on holistic page
- show units even when job info is blocked
- update kanban board link to holistic page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d0769972c832d8622bbad596c9b2a