### PR TITLE
Fix status mapping in holistic archive view

### DIFF
--- a/taintedpaint/app/holistic/page.tsx
+++ b/taintedpaint/app/holistic/page.tsx
@@ -40,8 +40,8 @@ interface Job extends Task {
 }
 
 const getStatus = (t: Task): Status => {
-  if (["archive", "archive2", "ship"].includes(t.columnId)) return "Finished"
-  if (["quote", "send"].includes(t.columnId)) return "Quoted"
+  if (t.columnId === "archive2") return "Finished"
+  if (t.columnId === "archive") return "Quoted"
   return "Working"
 }
 


### PR DESCRIPTION
## Summary
- update job status classification logic in `holistic/page.tsx`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687dd226cbb4832d8fd275f9bcaae732