### PR TITLE
Fix quoted label color

### DIFF
--- a/taintedpaint/app/holistic/page.tsx
+++ b/taintedpaint/app/holistic/page.tsx
@@ -51,7 +51,7 @@ const getStatus = (t: Task): Status => {
 // Status → 颜色 / 中文标签（淡色、Apple 风）----------------------------------
 const statusInfo = {
   Working:  { stripe: 'bg-blue-500',   badge: 'bg-blue-100 text-blue-800',   label: '进行中' },
-  Quoted:   { stripe: 'bg-orange-500', badge: 'bg-orange-100 text-orange-800', label: '已报价' },
+  Quoted:   { stripe: 'bg-yellow-500', badge: 'bg-yellow-100 text-yellow-800', label: '已报价' },
   Finished: { stripe: 'bg-green-500',  badge: 'bg-green-100 text-green-800',  label: '已完成' }
 };
 


### PR DESCRIPTION
## Summary
- adjust color palette for "已报价" status in holistic board

## Testing
- `npm test --prefix taintedpaint`

------
https://chatgpt.com/codex/tasks/task_e_687dda4f5a90832db2186e5eda862145