### PR TITLE
Refine archive column labels

### DIFF
--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -300,9 +300,9 @@ export default function KanbanBoard() {
                   {columnTasks.length === 0 ? (
                     <div className="h-full flex flex-col items-center justify-center text-center py-12">
                       <Archive className="h-12 w-12 text-gray-400 mb-4" strokeWidth={1.2} />
-                      <p className="text-sm font-medium text-gray-600 mb-1">归档区域</p>
+                      <p className="text-sm font-medium text-gray-600 mb-1">{column.title}区域</p>
                       <p className="text-xs text-gray-500 leading-relaxed">
-                        拖拽任务到此处归档
+                        拖拽任务到此处{column.title}
                         <br />
                         归档的任务将被保存
                       </p>

--- a/taintedpaint/lib/baseColumns.ts
+++ b/taintedpaint/lib/baseColumns.ts
@@ -9,10 +9,10 @@ export const baseColumns: Column[] = [
   { id: "create",      title: "建单",   taskIds: [] },
   { id: "quote",       title: "报价",   taskIds: [] },
   { id: "send",        title: "发出",   taskIds: [] },
-  { id: "archive",     title: "存档",   taskIds: [] },
+  { id: "archive",     title: "报价归档",   taskIds: [] },
   { id: "sheet",       title: "制单",   taskIds: [] },
   { id: "approval",    title: "审批",   taskIds: [] },
   { id: "program",     title: "编程",   taskIds: [] },
   { id: "ship",        title: "出货",   taskIds: [] },
-  { id: "archive2",    title: "存档",   taskIds: [] }
+  { id: "archive2",    title: "完成归档",   taskIds: [] }
 ];

--- a/taintedpaint/public/storage/metadata.json
+++ b/taintedpaint/public/storage/metadata.json
@@ -45,7 +45,7 @@
     },
     {
       "id": "archive",
-      "title": "存档",
+      "title": "报价归档",
       "taskIds": []
     },
     {
@@ -73,7 +73,7 @@
     },
     {
       "id": "archive2",
-      "title": "存档",
+      "title": "完成归档",
       "taskIds": []
     }
   ]


### PR DESCRIPTION
## Summary
- rename archive columns in base columns setup
- update sample metadata with new names
- clarify kanban board text for archive columns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687de03b8b48832d87620b1cd2362c54