### PR TITLE
Disable devtools by default

### DIFF
--- a/blackpaint/src/index.ts
+++ b/blackpaint/src/index.ts
@@ -35,8 +35,10 @@ const createWindow = (): void => {
   // and load the index.html of the app.
   mainWindow.loadURL(process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000');
 
-  // Open the DevTools.
-  mainWindow.webContents.openDevTools();
+  // Open the DevTools automatically when running in development.
+  if (!app.isPackaged) {
+    mainWindow.webContents.openDevTools();
+  }
 };
 
 // This method will be called when Electron has finished


### PR DESCRIPTION
## Summary
- open DevTools only when the app isn't packaged

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687def6a2d48832da4eb4e8534f00f37