### PR TITLE
Sanitize relative file path in update-file route

### DIFF
--- a/taintedpaint/test/pathUtils.test.js
+++ b/taintedpaint/test/pathUtils.test.js
@@ -18,4 +18,12 @@ test('rejects paths containing .. after normalization', () => {
   assert.throws(() => sanitizeRelativePath('foo/..mal/evil.txt'), /Invalid path/)
 })
 
+test('strips multiple leading parent directories', () => {
+  assert.strictEqual(sanitizeRelativePath('../../foo/bar.txt'), 'foo/bar.txt')
+})
+
+test('rejects paths with backslash traversals', () => {
+  assert.throws(() => sanitizeRelativePath('foo\\..\\evil.txt'), /Invalid path/)
+})
+
 


### PR DESCRIPTION
## Summary
- validate `relativePath` in the update-file API
- return an error for invalid paths
- add additional sanitizeRelativePath tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687df0748c90832daea84acd303d9c34