### PR TITLE
Default to server address when env var missing

### DIFF
--- a/blackpaint/src/index.ts
+++ b/blackpaint/src/index.ts
@@ -33,7 +33,8 @@ const createWindow = (): void => {
   }
 
   // and load the index.html of the app.
-  mainWindow.loadURL(process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000');
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://192.168.5.107:3000';
+  mainWindow.loadURL(appUrl);
 
   // Open the DevTools automatically when running in development.
   if (!app.isPackaged) {

--- a/blackpaint/src/sync.ts
+++ b/blackpaint/src/sync.ts
@@ -3,6 +3,8 @@ import path from 'path';
 import axios from 'axios';
 import chokidar, { FSWatcher } from 'chokidar';
 
+const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || 'http://192.168.5.107:3000';
+
 interface RemoteFile {
   filename: string;
   relativePath: string;
@@ -43,7 +45,7 @@ async function uploadFile(taskId: string, localRoot: string, relPath: string) {
   form.append('paths', relPath);
 
   try {
-    await fetch(`${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/api/jobs/${taskId}/upload`, {
+    await fetch(`${BASE_URL}/api/jobs/${taskId}/upload`, {
       method: 'POST',
       body: form,
     });
@@ -54,7 +56,7 @@ async function uploadFile(taskId: string, localRoot: string, relPath: string) {
 
 async function deleteFile(taskId: string, relPath: string) {
   try {
-    await fetch(`${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/api/jobs/${taskId}/delete-file`, {
+    await fetch(`${BASE_URL}/api/jobs/${taskId}/delete-file`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ filename: relPath }),
@@ -66,7 +68,7 @@ async function deleteFile(taskId: string, relPath: string) {
 
 async function pullFromServer(taskId: string, localRoot: string) {
   try {
-    const res = await axios.get<RemoteFile[]>(`${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/api/jobs/${taskId}/files`);
+    const res = await axios.get<RemoteFile[]>(`${BASE_URL}/api/jobs/${taskId}/files`);
     const files = res.data;
     for (const file of files) {
       const localPath = path.join(localRoot, file.relativePath);


### PR DESCRIPTION
## Summary
- open the Electron app using `NEXT_PUBLIC_APP_URL` when set
- otherwise, load from `http://192.168.5.107:3000`
- update sync logic to use the same fallback

## Testing
- `npm test --prefix taintedpaint`

------
https://chatgpt.com/codex/tasks/task_e_687e02606d70832d8917fc6caeb14287