### PR TITLE
Update icon to e-logo.png

### DIFF
--- a/blackpaint/forge.config.ts
+++ b/blackpaint/forge.config.ts
@@ -7,6 +7,7 @@ import { AutoUnpackNativesPlugin } from '@electron-forge/plugin-auto-unpack-nati
 import { WebpackPlugin } from '@electron-forge/plugin-webpack';
 import { FusesPlugin } from '@electron-forge/plugin-fuses';
 import { FuseV1Options, FuseVersion } from '@electron/fuses';
+import path from 'path';
 
 import { mainConfig } from './webpack.main.config';
 import { rendererConfig } from './webpack.renderer.config';
@@ -14,6 +15,7 @@ import { rendererConfig } from './webpack.renderer.config';
 const config: ForgeConfig = {
   packagerConfig: {
     asar: true,
+    icon: path.join(__dirname, 'assets', 'e-logo.png'),
   },
   rebuildConfig: {},
   makers: [new MakerSquirrel({}), new MakerZIP({}, ['darwin']), new MakerRpm({}), new MakerDeb({})],

--- a/blackpaint/src/index.ts
+++ b/blackpaint/src/index.ts
@@ -16,7 +16,7 @@ if (require('electron-squirrel-startup')) {
 
 const createWindow = (): void => {
   // Create the browser window.
-  const iconPath = path.join(__dirname, '../assets/electron-logo.svg');
+  const iconPath = path.join(__dirname, '../assets/e-logo.png');
   const icon = nativeImage.createFromPath(iconPath);
 
   const mainWindow = new BrowserWindow({


### PR DESCRIPTION
## Summary
- use the `e-logo.png` asset as the icon when launching Electron
- configure Electron Forge packager to use `e-logo.png`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_687e1dc3f7a8832d9bfa117457e237f0