### PR TITLE
Fix icon path resolution

### DIFF
--- a/blackpaint/src/index.ts
+++ b/blackpaint/src/index.ts
@@ -16,7 +16,7 @@ if (require('electron-squirrel-startup')) {
 
 const createWindow = (): void => {
   // Create the browser window.
-  const iconPath = path.join(__dirname, '../assets/e-logo.png');
+  const iconPath = path.join(app.getAppPath(), 'assets', 'e-logo.png');
   const icon = nativeImage.createFromPath(iconPath);
 
   const mainWindow = new BrowserWindow({


### PR DESCRIPTION
## Summary
- fix the `e-logo.png` icon path so it resolves from the project root

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687e20158d68832d924324d6214aca0e