### PR TITLE
Rename electron app to Eldaline

### DIFF
--- a/blackpaint/forge.config.ts
+++ b/blackpaint/forge.config.ts
@@ -15,11 +15,21 @@ import { rendererConfig } from './webpack.renderer.config';
 const config: ForgeConfig = {
   packagerConfig: {
     asar: true,
-    icon: path.join(__dirname, 'assets', 'e-logo'),
+    icon: path.join(__dirname, 'assets', 'e-logo.ico'),
     extraResources: [{ from: path.resolve(__dirname, 'assets'), to: 'assets' }],
   },
   rebuildConfig: {},
-  makers: [new MakerSquirrel({}), new MakerZIP({}, ['darwin']), new MakerRpm({}), new MakerDeb({})],
+  makers: [
+    new MakerSquirrel({
+      name: 'eldaline',
+      setupIcon: path.join(__dirname, 'assets', 'e-logo.ico'),
+      setupExe: 'EldalineSetup.exe',
+      exe: 'Eldaline.exe',
+    }),
+    new MakerZIP({}, ['darwin']),
+    new MakerRpm({}),
+    new MakerDeb({}),
+  ],
   plugins: [
     new AutoUnpackNativesPlugin({}),
     new WebpackPlugin({

--- a/blackpaint/package-lock.json
+++ b/blackpaint/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "blackpaint",
+  "name": "eldaline",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "blackpaint",
+      "name": "eldaline",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/blackpaint/package.json
+++ b/blackpaint/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "blackpaint",
-  "productName": "blackpaint",
+  "name": "eldaline",
+  "productName": "Eldaline",
   "version": "1.0.0",
   "description": "My Electron application description",
   "main": ".webpack/main",


### PR DESCRIPTION
## Summary
- rename the Electron package to **Eldaline**
- update forge config with proper icon and MakerSquirrel settings

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_687e2bd0069c832d9ffbbccf324120bc