### PR TITLE
Add new production phases

### DIFF
--- a/taintedpaint/components/SearchDialog.tsx
+++ b/taintedpaint/components/SearchDialog.tsx
@@ -152,7 +152,7 @@ export default function SearchDialog({ isOpen, onClose, onTaskSelect }: SearchDi
                   </div>
                   <div className="flex-1 min-w-0">
                     <h3 className="text-sm font-semibold text-gray-800 truncate">
-                      {['sheet', 'approval', 'program', 'ship', 'archive2'].includes(task.columnId)
+                      {['sheet', 'approval', 'program', 'operate', 'polish', 'spray', 'inspect', 'ship', 'archive2'].includes(task.columnId)
                         ? task.ynmxId || `${task.customerName} - ${task.representative}`
                         : `${task.customerName} - ${task.representative}`}
                     </h3>

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -25,6 +25,10 @@ export default function KanbanBoard() {
     sheet: 'bg-orange-500',
     approval: 'bg-yellow-500',
     program: 'bg-indigo-500',
+    operate: 'bg-cyan-500',
+    polish: 'bg-pink-500',
+    spray: 'bg-rose-500',
+    inspect: 'bg-lime-500',
     ship: 'bg-green-500',
     archive: 'bg-gray-400',
     archive2: 'bg-gray-400',
@@ -79,7 +83,7 @@ export default function KanbanBoard() {
   }, []);
 
   const getTaskDisplayName = (task: Task) => {
-    if (['sheet', 'approval', 'program', 'ship', 'archive2'].includes(task.columnId)) {
+    if (['sheet', 'approval', 'program', 'operate', 'polish', 'spray', 'inspect', 'ship', 'archive2'].includes(task.columnId)) {
       return task.ynmxId || `${task.customerName} - ${task.representative}`;
     }
     return `${task.customerName} - ${task.representative}`;
@@ -210,7 +214,7 @@ export default function KanbanBoard() {
   const allTasksForSearch = useMemo(() => Object.values(tasks), [tasks]);
   const visibleColumns = useMemo(() => {
     if (viewMode === 'production') {
-      return columns.filter(c => ['approval', 'program', 'ship', 'archive2'].includes(c.id))
+      return columns.filter(c => ['approval', 'program', 'operate', 'polish', 'spray', 'inspect', 'ship', 'archive2'].includes(c.id))
     }
     return columns
   }, [viewMode, columns])

--- a/taintedpaint/lib/baseColumns.ts
+++ b/taintedpaint/lib/baseColumns.ts
@@ -13,6 +13,10 @@ export const baseColumns: Column[] = [
   { id: "sheet",       title: "制单",   taskIds: [] },
   { id: "approval",    title: "审批",   taskIds: [] },
   { id: "program",     title: "编程",   taskIds: [] },
+  { id: "operate",     title: "操机",   taskIds: [] },
+  { id: "polish",      title: "打磨",   taskIds: [] },
+  { id: "spray",       title: "喷涂",   taskIds: [] },
+  { id: "inspect",     title: "检验",   taskIds: [] },
   { id: "ship",        title: "出货",   taskIds: [] },
   { id: "archive2",    title: "完成归档",   taskIds: [] }
 ];

--- a/taintedpaint/public/storage/metadata.json
+++ b/taintedpaint/public/storage/metadata.json
@@ -67,6 +67,26 @@
       "taskIds": []
     },
     {
+      "id": "operate",
+      "title": "操机",
+      "taskIds": []
+    },
+    {
+      "id": "polish",
+      "title": "打磨",
+      "taskIds": []
+    },
+    {
+      "id": "spray",
+      "title": "喷涂",
+      "taskIds": []
+    },
+    {
+      "id": "inspect",
+      "title": "检验",
+      "taskIds": []
+    },
+    {
       "id": "ship",
       "title": "出货",
       "taskIds": []


### PR DESCRIPTION
## Summary
- extend base columns with 操机、打磨、喷涂、检验
- show these columns in kanban board
- show these stages in search results
- update stored metadata

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f1ee660b8832d9981c5bb26619fc6