### PR TITLE
Improve card details for admins

### DIFF
--- a/taintedpaint/components/KanbanDrawer.tsx
+++ b/taintedpaint/components/KanbanDrawer.tsx
@@ -4,13 +4,7 @@
 import type { Task } from "@/types";
 import type { ElectronAPI } from "@/types/electron";
 import { useState, useCallback } from "react";
-import { X, CalendarDays, MessageSquare, Folder, FileCode } from "lucide-react";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { X, CalendarDays, MessageSquare, Folder } from "lucide-react";
 
 interface KanbanDrawerProps {
   isOpen: boolean;
@@ -26,7 +20,6 @@ export default function KanbanDrawer({
   onClose,
 }: KanbanDrawerProps) {
   const [isDownloading, setIsDownloading] = useState(false);
-  const [showMetadata, setShowMetadata] = useState(false);
 
   const handleDownloadAndOpen = useCallback(async () => {
     if (!task) return;
@@ -139,32 +132,9 @@ export default function KanbanDrawer({
               </div>
             </button>
 
-            <button
-              onClick={() => setShowMetadata(true)}
-              className="w-full flex items-center gap-4 p-4 bg-black/5 hover:bg-black/10 rounded-lg transition-all duration-200"
-            >
-              <div className="flex items-center justify-center h-10 w-10 rounded bg-black/10">
-                <FileCode className="h-5 w-5 text-black/70" />
-              </div>
-              <div className="flex-1 text-left">
-                <p className="text-[15px] font-medium text-black">查看元数据</p>
-                <p className="text-[13px] text-black/50">显示此任务的原始记录</p>
-              </div>
-            </button>
           </div>
         </div>
       </aside>
-
-      <Dialog open={showMetadata} onOpenChange={setShowMetadata}>
-        <DialogContent className="max-w-xl" showCloseButton>
-          <DialogHeader>
-            <DialogTitle>任务元数据</DialogTitle>
-          </DialogHeader>
-          <pre className="mt-4 text-sm bg-black/5 rounded-md p-4 whitespace-pre-wrap overflow-x-auto">
-{JSON.stringify(task, null, 2)}
-          </pre>
-        </DialogContent>
-      </Dialog>
     </>
   );
 }

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -83,7 +83,7 @@ export default function KanbanBoard() {
   }, []);
 
   const getTaskDisplayName = (task: Task) => {
-    if (['sheet', 'approval', 'program', 'operate', 'polish', 'spray', 'inspect', 'ship', 'archive2'].includes(task.columnId)) {
+    if (viewMode === 'production') {
       return task.ynmxId || `${task.customerName} - ${task.representative}`;
     }
     return `${task.customerName} - ${task.representative}`;
@@ -335,10 +335,22 @@ export default function KanbanBoard() {
                           <div className="pl-4 pr-2">
                             <div className={`p-1 -m-1 rounded-md transition-colors duration-500 ${highlightedTaskId === task.id ? 'bg-yellow-200/70' : 'bg-transparent'}`}
                             >
-                              <h3 className="text-sm font-medium text-gray-800 mb-1.5 leading-tight group-hover:text-gray-900 transition-colors">
-                                {getTaskDisplayName(task)}
-                              </h3>
-                              <p className="text-xs text-gray-500 leading-relaxed">{task.orderDate}</p>
+                              {viewMode === 'business' ? (
+                                <>
+                                  <h3 className="text-sm font-medium text-gray-800 leading-tight group-hover:text-gray-900 transition-colors">
+                                    {task.customerName}
+                                  </h3>
+                                  <p className="text-xs text-gray-500">{task.representative}</p>
+                                  {task.ynmxId && (
+                                    <p className="text-xs text-gray-400">{task.ynmxId}</p>
+                                  )}
+                                </>
+                              ) : (
+                                <h3 className="text-sm font-medium text-gray-800 leading-tight group-hover:text-gray-900 transition-colors">
+                                  {getTaskDisplayName(task)}
+                                </h3>
+                              )}
+                              <p className="text-xs text-gray-500 leading-relaxed mt-0.5">{task.orderDate}</p>
                             </div>
                           </div>
                         </Card>
@@ -384,10 +396,22 @@ export default function KanbanBoard() {
                       <div className="pl-4 pr-2">
                         <div className={`p-1 -m-1 rounded-md transition-colors duration-500 ${highlightedTaskId === task.id ? 'bg-yellow-200/70' : 'bg-transparent'}`}
                         >
-                          <h3 className="text-sm font-medium text-gray-800 mb-1.5 leading-tight group-hover:text-gray-900 transition-colors">
-                            {getTaskDisplayName(task)}
-                          </h3>
-                          <p className="text-xs text-gray-500 leading-relaxed">{task.orderDate}</p>
+                          {viewMode === 'business' ? (
+                            <>
+                              <h3 className="text-sm font-medium text-gray-800 leading-tight group-hover:text-gray-900 transition-colors">
+                                {task.customerName}
+                              </h3>
+                              <p className="text-xs text-gray-500">{task.representative}</p>
+                              {task.ynmxId && (
+                                <p className="text-xs text-gray-400">{task.ynmxId}</p>
+                              )}
+                            </>
+                          ) : (
+                            <h3 className="text-sm font-medium text-gray-800 leading-tight group-hover:text-gray-900 transition-colors">
+                              {getTaskDisplayName(task)}
+                            </h3>
+                          )}
+                          <p className="text-xs text-gray-500 leading-relaxed mt-0.5">{task.orderDate}</p>
                         </div>
                       </div>
                     </Card>


### PR DESCRIPTION
## Summary
- keep detailed card info visible in business mode
- hide metadata viewer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f37e63054832da2682da674e4f89b