### PR TITLE
Add restricted electron build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# CrystalPaint Setup
+
+This repository contains two parts:
+
+- `taintedpaint` – the Next.js web app.
+- `blackpaint` – the Electron wrapper named **Eldaline**.
+
+Two Electron builds can be produced:
+
+1. **Administrator build** – full access.
+2. **Production build** – locked to production view with some UI disabled.
+
+## Web App
+
+```
+cd taintedpaint
+npm install
+npm run dev
+```
+
+By default the web app runs on `http://localhost:3000`. Set `NEXT_PUBLIC_APP_URL` in the environment if the Electron app should point elsewhere.
+
+## Building Electron Apps
+
+```
+cd blackpaint
+npm install
+```
+
+### Administrator version
+
+```
+npm run make
+```
+
+### Production version
+
+```
+npm run make:restricted
+```
+
+The production build adds `?restricted=1` to the web URL so the web interface automatically hides the Business switcher and Holistic view.
+
+The packaged apps can be found in `blackpaint/out` after running the commands.

--- a/blackpaint/package.json
+++ b/blackpaint/package.json
@@ -8,6 +8,7 @@
     "start": "electron-forge start",
     "package": "electron-forge package",
     "make": "electron-forge make",
+    "make:restricted": "cross-env RESTRICTED=1 electron-forge make",
     "publish": "electron-forge publish",
     "lint": "eslint --ext .ts,.tsx ."
   },
@@ -35,6 +36,7 @@
     "@vercel/webpack-asset-relocator-loader": "^1.7.3",
     "babel-loader": "^10.0.0",
     "css-loader": "^6.11.0",
+    "cross-env": "^7.0.3",
     "electron": "37.2.3",
     "eslint": "^8.57.1",
     "eslint-plugin-import": "^2.32.0",

--- a/blackpaint/src/index.ts
+++ b/blackpaint/src/index.ts
@@ -33,7 +33,8 @@ const createWindow = (): void => {
   }
 
   // and load the index.html of the app.
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://192.168.5.107:3000';
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://192.168.5.107:3000';
+  const appUrl = process.env.RESTRICTED ? `${baseUrl}?restricted=1` : baseUrl;
   mainWindow.loadURL(appUrl);
 
   // Open the DevTools automatically when running in development.

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -5,16 +5,22 @@ import type { Task, Column, BoardData } from "@/types"
 import { useState, useEffect, useCallback, useMemo, useRef } from "react"
 import CreateJobForm from "@/components/CreateJobForm"
 import { Card } from "@/components/ui/card"
-import { Archive, Search, LayoutGrid } from "lucide-react"
+import { Archive, Search, LayoutGrid, Lock } from "lucide-react"
 import Link from "next/link"
 import { baseColumns, START_COLUMN_ID } from "@/lib/baseColumns"
 import KanbanDrawer from "@/components/KanbanDrawer"
 import SearchDialog from "@/components/SearchDialog"
 
 export default function KanbanBoard() {
+  const restricted =
+    typeof window !== 'undefined' &&
+    new URLSearchParams(window.location.search).get('restricted') === '1'
+
   const [tasks, setTasks] = useState<Record<string, Task>>({})
   const [columns, setColumns] = useState<Column[]>(baseColumns)
-  const [viewMode, setViewMode] = useState<'business' | 'production'>('business')
+  const [viewMode, setViewMode] = useState<'business' | 'production'>(
+    restricted ? 'production' : 'business',
+  )
   const [draggedTask, setDraggedTask] = useState<Task | null>(null)
   const [dragOverColumn, setDragOverColumn] = useState<string | null>(null)
 
@@ -231,9 +237,11 @@ export default function KanbanBoard() {
           <div className="flex items-center gap-4">
             <div className="flex bg-gray-100/50 backdrop-blur-sm border border-gray-200/60 rounded-md p-0.5">
               <button
-                onClick={() => setViewMode('business')}
-                className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${viewMode === 'business' ? 'bg-white shadow text-gray-900' : 'text-gray-600 hover:text-gray-800'}`}
+                onClick={() => !restricted && setViewMode('business')}
+                className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${viewMode === 'business' ? 'bg-white shadow text-gray-900' : 'text-gray-600 hover:text-gray-800'} ${restricted ? 'cursor-not-allowed opacity-50 flex items-center gap-1' : ''}`}
+                disabled={restricted}
               >
+                {restricted && <Lock className="h-3 w-3" strokeWidth={2} />}
                 商务
               </button>
               <button
@@ -263,10 +271,17 @@ export default function KanbanBoard() {
               </div>
             </button>
 
-            <Link href="/holistic" className="group relative flex items-center justify-center gap-2.5 px-4 py-2.5 bg-gray-100/60 backdrop-blur-sm border border-gray-200/60 hover:border-gray-300/80 rounded-md shadow-sm hover:shadow-md transform-gpu transition-all duration-200 ease-out hover:bg-white/80 active:scale-[0.96]">
-              <LayoutGrid className="h-4 w-4 text-gray-500 group-hover:text-gray-700 transition-colors duration-200" strokeWidth={2} />
-              <span className="text-sm font-medium text-gray-600 group-hover:text-gray-800 transition-colors duration-200">总揽</span>
-            </Link>
+            {restricted ? (
+              <div className="group relative flex items-center justify-center gap-2.5 px-4 py-2.5 bg-gray-100/60 backdrop-blur-sm border border-gray-200/60 rounded-md shadow-sm cursor-not-allowed opacity-50">
+                <LayoutGrid className="h-4 w-4 text-gray-400" strokeWidth={2} />
+                <Lock className="h-4 w-4 text-gray-400" strokeWidth={2} />
+              </div>
+            ) : (
+              <Link href="/holistic" className="group relative flex items-center justify-center gap-2.5 px-4 py-2.5 bg-gray-100/60 backdrop-blur-sm border border-gray-200/60 hover:border-gray-300/80 rounded-md shadow-sm hover:shadow-md transform-gpu transition-all duration-200 ease-out hover:bg-white/80 active:scale-[0.96]">
+                <LayoutGrid className="h-4 w-4 text-gray-500 group-hover:text-gray-700 transition-colors duration-200" strokeWidth={2} />
+                <span className="text-sm font-medium text-gray-600 group-hover:text-gray-800 transition-colors duration-200">总揽</span>
+              </Link>
+            )}
           </div>
         </div>
       </header>


### PR DESCRIPTION
## Summary
- add README with setup instructions
- allow building a restricted Eldaline version
- load restricted mode with query parameter when building restricted
- disable business switch and holistic link in restricted mode

## Testing
- `cd taintedpaint && npm test`
- `npm run lint` *(fails: `next` not found)*
- `cd ../blackpaint && npm test` *(fails: missing script)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_687f48fadd2c832d8a187a134b0da539