### PR TITLE
Fix restricted Electron build

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,8 @@ npm run make:restricted
 
 The production build adds `?restricted=1` to the web URL so the web interface automatically hides the Business switcher and Holistic view.
 
+### Why it mattered
+
+Initially the `make:restricted` script set the `RESTRICTED` environment variable only while running the build. Because the packaged application started without that variable present, `process.env.RESTRICTED` evaluated to `undefined`, so the restricted mode was never enabled. Webpack now copies the value of `RESTRICTED` into the bundled code at build time, ensuring the production package always loads with the proper query parameter.
+
 The packaged apps can be found in `blackpaint/out` after running the commands.

--- a/blackpaint/README.md
+++ b/blackpaint/README.md
@@ -1,0 +1,23 @@
+# Eldaline (Blackpaint)
+
+This folder contains the Electron wrapper for the `taintedpaint` web
+application. Two distributable versions exist:
+
+- **Administrator** – no restrictions, loads the web app directly.
+- **Production** – restricted view. The Electron window loads the web URL with
+  `?restricted=1` appended. Inside `taintedpaint` this query param disables the
+  商务 tab and 总揽 switcher so production workers only see the 生产 section.
+
+The build script `npm run make:restricted` sets the `RESTRICTED` environment
+variable and Webpack's `EnvironmentPlugin` embeds its value into the compiled
+code. The main process checks this value and appends the query parameter when
+creating the browser window.
+
+Run one of these inside this folder after installing dependencies:
+
+```bash
+npm run make        # Administrator build
+npm run make:restricted  # Production build
+```
+
+The generated installers will be in `out/`.

--- a/blackpaint/webpack.main.config.ts
+++ b/blackpaint/webpack.main.config.ts
@@ -2,6 +2,7 @@ import type { Configuration } from 'webpack';
 
 import { rules } from './webpack.rules';
 import { plugins } from './webpack.plugins';
+import webpack from 'webpack';
 
 export const mainConfig: Configuration = {
   /**
@@ -13,7 +14,10 @@ export const mainConfig: Configuration = {
   module: {
     rules,
   },
-  plugins,
+  plugins: [
+    ...plugins,
+    new webpack.EnvironmentPlugin({ RESTRICTED: undefined }),
+  ],
   resolve: {
     extensions: ['.js', '.ts', '.jsx', '.tsx', '.css', '.json'],
   },

--- a/blackpaint/webpack.renderer.config.ts
+++ b/blackpaint/webpack.renderer.config.ts
@@ -2,6 +2,7 @@ import type { Configuration } from 'webpack';
 
 import { rules } from './webpack.rules';
 import { plugins } from './webpack.plugins';
+import webpack from 'webpack';
 
 rules.push({
   test: /\.css$/,
@@ -12,7 +13,10 @@ export const rendererConfig: Configuration = {
   module: {
     rules,
   },
-  plugins,
+  plugins: [
+    ...plugins,
+    new webpack.EnvironmentPlugin({ RESTRICTED: undefined }),
+  ],
   resolve: {
     extensions: ['.js', '.ts', '.jsx', '.tsx', '.css'],
   },


### PR DESCRIPTION
## Summary
- preserve `RESTRICTED` environment variable when packaging the Electron app
- update documentation on why restricted builds didn't work
- explain build process in `blackpaint/README.md`

## Testing
- `npm test --prefix taintedpaint`
- `npm run lint --prefix blackpaint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_687f4e5aace8832daa25c31eb90d1daa