### PR TITLE
Update card date labels and rename order date

### DIFF
--- a/taintedpaint/app/api/jobs/route.ts
+++ b/taintedpaint/app/api/jobs/route.ts
@@ -31,7 +31,7 @@ export async function POST(req: NextRequest) {
     const filePaths = formData.getAll("filePaths") as string[];
     const customerName = formData.get("customerName") as string;
     const representative = formData.get("representative") as string;
-    const orderDate = formData.get("orderDate") as string;
+    const inquiryDate = formData.get("inquiryDate") as string;
     const notes = formData.get("notes") as string;
 
     // deliveryDate is optional on creation
@@ -46,7 +46,7 @@ export async function POST(req: NextRequest) {
       files.length === 0 ||
       !customerName ||
       !representative ||
-      !orderDate ||
+      !inquiryDate ||
       !folderName // Add validation for the folder name
     ) {
       return NextResponse.json(
@@ -76,7 +76,7 @@ export async function POST(req: NextRequest) {
       columnId: START_COLUMN_ID,
       customerName: customerName.trim(),
       representative: representative.trim(),
-      orderDate: orderDate.trim(),
+      inquiryDate: inquiryDate.trim(),
       deliveryDate,
       notes: notes.trim(),
       taskFolderPath: `/storage/tasks/${taskId}`,

--- a/taintedpaint/app/api/search/route.ts
+++ b/taintedpaint/app/api/search/route.ts
@@ -13,7 +13,7 @@ function serialiseTasks(tasks: BoardData["tasks"]): string {
   return Object.values(tasks)
     .map(
       (t) =>
-        `ID:${t.id} COL:${t.columnId} CUSTOMER:${t.customerName} REPRESENTATIVE:${t.representative} DATE:${t.orderDate} NOTES:${t.notes}`
+        `ID:${t.id} COL:${t.columnId} CUSTOMER:${t.customerName} REPRESENTATIVE:${t.representative} DATE:${t.inquiryDate} NOTES:${t.notes}`
     )
     .join("\n");
 }

--- a/taintedpaint/app/holistic/page.tsx
+++ b/taintedpaint/app/holistic/page.tsx
@@ -79,7 +79,7 @@ export default function ArchivePage() {
   , [tasks]);
 
   const customers = useMemo(() => Array.from(new Set(jobs.map(j => j.customerName))), [jobs]);
-  const months    = useMemo(() => Array.from(new Set(jobs.map(j => dayjs(j.orderDate).format("YYYY-MM")))), [jobs]);
+  const months    = useMemo(() => Array.from(new Set(jobs.map(j => dayjs(j.inquiryDate).format("YYYY-MM")))), [jobs]);
 
   // ② 组件状态 --------------------------------------------------------------------
   const [activeCustomer, setActiveCustomer] = useState<string>('All');
@@ -94,11 +94,11 @@ export default function ArchivePage() {
   const filtered = jobs
     .filter(j => {
       const okCustomer = activeCustomer === "All" || j.customerName === activeCustomer;
-      const okMonth = activeMonth === "All" || dayjs(j.orderDate).format("YYYY-MM") === activeMonth;
+      const okMonth = activeMonth === "All" || dayjs(j.inquiryDate).format("YYYY-MM") === activeMonth;
       const okSearch = q === "" || j.representative.toLowerCase().includes(q.toLowerCase());
       return okCustomer && okMonth && okSearch;
     })
-    .sort((a, b) => dayjs(b.orderDate).valueOf() - dayjs(a.orderDate).valueOf());
+    .sort((a, b) => dayjs(b.inquiryDate).valueOf() - dayjs(a.inquiryDate).valueOf());
 
   // ④ 指标计算 --------------------------------------------------------------------
   const working  = filtered.filter(j => j.status === 'Working').length;
@@ -107,7 +107,7 @@ export default function ArchivePage() {
   const denom    = quoted + finished;                        // 已报价 + 已完成
   const hitRate  = denom === 0 ? 0 : Math.round((finished / denom) * 100);
   const byDay = filtered.reduce<Record<string, Job[]>>((acc, job) => {
-    const d = dayjs(job.orderDate).format("MMM DD");
+    const d = dayjs(job.inquiryDate).format("MMM DD");
     (acc[d] = acc[d] || []).push(job);
     return acc;
   }, {});
@@ -266,7 +266,7 @@ function JobCard({ job, onClick }: { job: Job; onClick: () => void }) {
           </span>
         </div>
 
-        <p className="text-xs text-gray-400 mb-3 font-mono tracking-wide">{dayjs(job.orderDate).format('YYYY-MM-DD')}</p>
+        <p className="text-xs text-gray-400 mb-3 font-mono tracking-wide">{dayjs(job.inquiryDate).format('YYYY-MM-DD')}</p>
 
         <div className="flex items-center gap-3 text-xs text-gray-600">
           {job.value ? (

--- a/taintedpaint/components/CreateJobForm.tsx
+++ b/taintedpaint/components/CreateJobForm.tsx
@@ -16,7 +16,7 @@ export default function CreateJobForm({ onJobCreated }: CreateJobFormProps) {
   const [selectedFiles, setSelectedFiles] = useState<FileList | null>(null);
   const [customerName, setCustomerName] = useState("");
   const [representative, setRepresentative] = useState("");
-  const [orderDate, setOrderDate] = useState("");
+  const [inquiryDate, setInquiryDate] = useState("");
   const [notes, setNotes] = useState("");
   const [isCreating, setIsCreating] = useState(false);
   const [customerOptions, setCustomerOptions] = useState<string[]>([]);
@@ -24,7 +24,7 @@ export default function CreateJobForm({ onJobCreated }: CreateJobFormProps) {
 
   // 初始化日期为今天，并读取已有客户列表供输入时选择
   useEffect(() => {
-    setOrderDate(new Date().toISOString().slice(0, 10));
+    setInquiryDate(new Date().toISOString().slice(0, 10));
 
     (async () => {
       try {
@@ -57,7 +57,7 @@ export default function CreateJobForm({ onJobCreated }: CreateJobFormProps) {
       selectedFiles.length === 0 ||
       !customerName.trim() ||
       !representative.trim() ||
-      !orderDate.trim()
+      !inquiryDate.trim()
     )
       return;
 
@@ -74,7 +74,7 @@ export default function CreateJobForm({ onJobCreated }: CreateJobFormProps) {
       
       formData.append("customerName", customerName.trim());
       formData.append("representative", representative.trim());
-      formData.append("orderDate", orderDate.trim());
+      formData.append("inquiryDate", inquiryDate.trim());
       formData.append("notes", notes.trim());
       formData.append("folderName", getFolderName());
 
@@ -93,7 +93,7 @@ export default function CreateJobForm({ onJobCreated }: CreateJobFormProps) {
       setSelectedFiles(null);
       setCustomerName("");
       setRepresentative("");
-      setOrderDate("");
+      setInquiryDate("");
       setNotes("");
       if (fileInputRef.current) {
         fileInputRef.current.value = "";
@@ -162,8 +162,8 @@ export default function CreateJobForm({ onJobCreated }: CreateJobFormProps) {
         <Input
           type="date"
           placeholder="日期"
-          value={orderDate}
-          onChange={(e) => setOrderDate(e.target.value)}
+          value={inquiryDate}
+          onChange={(e) => setInquiryDate(e.target.value)}
           className="text-sm bg-gray-100 border-none rounded-md px-3 py-2.5 h-auto focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 placeholder:text-gray-500"
         />
         <Input
@@ -182,7 +182,7 @@ export default function CreateJobForm({ onJobCreated }: CreateJobFormProps) {
           selectedFiles.length === 0 ||
           !customerName ||
           !representative ||
-          !orderDate ||
+          !inquiryDate ||
           isCreating
         }
       >

--- a/taintedpaint/components/KanbanDrawer.tsx
+++ b/taintedpaint/components/KanbanDrawer.tsx
@@ -133,9 +133,9 @@ export default function KanbanDrawer({
             <div className="flex items-center justify-between py-3 border-b border-black/[0.08]">
               <div className="flex items-center gap-3">
                 <CalendarDays className="h-4 w-4 text-black/40" />
-                <span className="text-[15px] text-black/60">订单日期</span>
+                <span className="text-[15px] text-black/60">询价日期</span>
               </div>
-              <span className="text-[15px] font-medium text-black">{task.orderDate}</span>
+              <span className="text-[15px] font-medium text-black">{task.inquiryDate}</span>
             </div>
             <div className="flex items-center justify-between py-3 border-b border-black/[0.08]">
               <div className="flex items-center gap-3">

--- a/taintedpaint/components/SearchDialog.tsx
+++ b/taintedpaint/components/SearchDialog.tsx
@@ -156,7 +156,7 @@ export default function SearchDialog({ isOpen, onClose, onTaskSelect }: SearchDi
                         ? task.ynmxId || `${task.customerName} - ${task.representative}`
                         : `${task.customerName} - ${task.representative}`}
                     </h3>
-                    <p className="text-xs text-gray-600">{task.deliveryDate || task.orderDate}</p>
+                    <p className="text-xs text-gray-600">{task.deliveryDate || task.inquiryDate}</p>
                   </div>
                   <span className="ml-auto flex-shrink-0 text-xs text-gray-700 bg-gray-200/80 px-2 py-1 rounded-full border border-gray-300/50">
                     {columnTitle}

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -365,7 +365,11 @@ export default function KanbanBoard() {
                                   {getTaskDisplayName(task)}
                                 </h3>
                               )}
-                              <p className="text-xs text-gray-500 leading-relaxed mt-0.5">{task.deliveryDate || task.orderDate}</p>
+                              <p className="text-xs text-gray-500 leading-relaxed mt-0.5">
+                                {task.deliveryDate
+                                  ? `交期: ${task.deliveryDate}`
+                                  : `询价日期: ${task.inquiryDate}`}
+                              </p>
                             </div>
                           </div>
                         </Card>
@@ -426,7 +430,11 @@ export default function KanbanBoard() {
                               {getTaskDisplayName(task)}
                             </h3>
                           )}
-                          <p className="text-xs text-gray-500 leading-relaxed mt-0.5">{task.deliveryDate || task.orderDate}</p>
+                          <p className="text-xs text-gray-500 leading-relaxed mt-0.5">
+                            {task.deliveryDate
+                              ? `交期: ${task.deliveryDate}`
+                              : `询价日期: ${task.inquiryDate}`}
+                          </p>
                         </div>
                       </div>
                     </Card>

--- a/taintedpaint/public/storage/metadata.json
+++ b/taintedpaint/public/storage/metadata.json
@@ -5,7 +5,7 @@
       "columnId": "approval",
       "customerName": "efw",
       "representative": "fwe",
-      "orderDate": "wef",
+      "inquiryDate": "wef",
       "notes": "ewf",
       "taskFolderPath": "/storage/tasks/1753021763511",
       "files": [
@@ -18,7 +18,7 @@
       "columnId": "approval",
       "customerName": "大华",
       "representative": "我",
-      "orderDate": "2025-07-20",
+      "inquiryDate": "2025-07-20",
       "notes": "",
       "taskFolderPath": "/storage/tasks/1753026660078",
       "files": [

--- a/taintedpaint/types.ts
+++ b/taintedpaint/types.ts
@@ -5,7 +5,7 @@ export interface Task {
   columnId: string; // <-- NEW
   customerName: string;
   representative: string;
-  orderDate: string;
+  inquiryDate: string;
   /** Required delivery date, editable in the Kanban drawer */
   deliveryDate?: string;
   notes: string;


### PR DESCRIPTION
## Summary
- rename `orderDate` field to `inquiryDate`
- show `询价日期` for tasks without a delivery date
- show `交期` when a delivery date exists
- update Kanban drawer wording
- adjust API and sample data

## Testing
- `npm test`
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f82aac128832d963e74e36baa1a6d