### PR TITLE
Set default RESTRICTED env var

### DIFF
--- a/blackpaint/webpack.main.config.ts
+++ b/blackpaint/webpack.main.config.ts
@@ -16,7 +16,7 @@ export const mainConfig: Configuration = {
   },
   plugins: [
     ...plugins,
-    new webpack.EnvironmentPlugin({ RESTRICTED: undefined }),
+    new webpack.EnvironmentPlugin({ RESTRICTED: '' }),
   ],
   resolve: {
     extensions: ['.js', '.ts', '.jsx', '.tsx', '.css', '.json'],

--- a/blackpaint/webpack.renderer.config.ts
+++ b/blackpaint/webpack.renderer.config.ts
@@ -15,7 +15,7 @@ export const rendererConfig: Configuration = {
   },
   plugins: [
     ...plugins,
-    new webpack.EnvironmentPlugin({ RESTRICTED: undefined }),
+    new webpack.EnvironmentPlugin({ RESTRICTED: '' }),
   ],
   resolve: {
     extensions: ['.js', '.ts', '.jsx', '.tsx', '.css'],


### PR DESCRIPTION
## Summary
- update webpack configs to set a safe default for `RESTRICTED`

## Testing
- `npm test` in `taintedpaint`
- `npm run lint` in `blackpaint` *(fails: couldn't find an eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_687f861f7fb8832d86c067c3049f8e66