### PR TITLE
Remove inline date pickers

### DIFF
--- a/taintedpaint/components/CreateJobForm.tsx
+++ b/taintedpaint/components/CreateJobForm.tsx
@@ -22,23 +22,17 @@ export default function CreateJobForm({ onJobCreated }: CreateJobFormProps) {
   const [customerOptions, setCustomerOptions] = useState<string[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const inquiryDateInputRef = useRef<HTMLInputElement>(null);
-  const [showInquiryPicker, setShowInquiryPicker] = useState(false);
 
-  const toggleInquiryDatePicker = () => {
-    setShowInquiryPicker((v) => !v);
-  };
-
-  useEffect(() => {
-    if (showInquiryPicker) {
-      const input = inquiryDateInputRef.current;
-      if (input) {
-        if ((input as any).showPicker) {
-          (input as any).showPicker();
-        }
-        input.focus();
-      }
+  const openInquiryDatePicker = () => {
+    const input = inquiryDateInputRef.current;
+    if (!input) return;
+    if ((input as any).showPicker) {
+      (input as any).showPicker();
+    } else {
+      input.focus();
+      input.click();
     }
-  }, [showInquiryPicker]);
+  };
 
   // 读取已有客户列表供输入时选择
   useEffect(() => {
@@ -184,7 +178,7 @@ export default function CreateJobForm({ onJobCreated }: CreateJobFormProps) {
           />
           <button
             type="button"
-            onClick={toggleInquiryDatePicker}
+            onClick={openInquiryDatePicker}
             className="absolute right-2 top-1/2 -translate-y-1/2 text-neutral-500 hover:text-neutral-700"
             aria-label="选择询价日期"
           >
@@ -195,7 +189,7 @@ export default function CreateJobForm({ onJobCreated }: CreateJobFormProps) {
             type="date"
             value={inquiryDate}
             onChange={(e) => setInquiryDate(e.target.value)}
-            className={`absolute right-0 top-full mt-1 w-40 bg-white border rounded-md p-1 text-sm shadow transition-all duration-300 origin-top ${showInquiryPicker ? '' : 'scale-90 opacity-0 pointer-events-none'}`}
+            className="sr-only"
             style={{ colorScheme: 'light' }}
           />
         </div>

--- a/taintedpaint/components/KanbanDrawer.tsx
+++ b/taintedpaint/components/KanbanDrawer.tsx
@@ -32,23 +32,17 @@ export default function KanbanDrawer({
   const [isDownloading, setIsDownloading] = useState(false);
   const [deliveryDate, setDeliveryDate] = useState("");
   const dateInputRef = useRef<HTMLInputElement>(null);
-  const [showDatePicker, setShowDatePicker] = useState(false);
 
-  const toggleDatePicker = () => {
-    setShowDatePicker((v) => !v);
-  };
-
-  useEffect(() => {
-    if (showDatePicker) {
-      const input = dateInputRef.current;
-      if (input) {
-        if ((input as any).showPicker) {
-          (input as any).showPicker();
-        }
-        input.focus();
-      }
+  const openDatePicker = () => {
+    const input = dateInputRef.current;
+    if (!input) return;
+    if ((input as any).showPicker) {
+      (input as any).showPicker();
+    } else {
+      input.focus();
+      input.click();
     }
-  }, [showDatePicker]);
+  };
 
   useEffect(() => {
     setDeliveryDate(task?.deliveryDate || "");
@@ -168,7 +162,7 @@ export default function KanbanDrawer({
                   <span className="text-[15px] font-medium text-black">{deliveryDate}</span>
                 )}
                 <button
-                  onClick={toggleDatePicker}
+                  onClick={openDatePicker}
                   className="h-7 w-7 flex items-center justify-center rounded-md bg-black/5 hover:bg-black/10 transition-colors"
                   aria-label="设置交期"
                 >
@@ -182,7 +176,7 @@ export default function KanbanDrawer({
                     setDeliveryDate(e.target.value);
                     saveDeliveryDate(e.target.value);
                   }}
-                  className={`absolute right-0 top-full mt-1 w-40 bg-white border rounded-md p-1 text-sm shadow transition-all duration-300 origin-top ${showDatePicker ? '' : 'scale-90 opacity-0 pointer-events-none'}`}
+                  className="sr-only"
                   style={{ colorScheme: 'light' }}
                 />
               </div>


### PR DESCRIPTION
## Summary
- stop showing inline date inputs when editing dates
- keep hidden inputs for date selection

## Testing
- `npm test --prefix taintedpaint`

------
https://chatgpt.com/codex/tasks/task_e_687f99dc7b30832da75157b8d919abc6