### PR TITLE
Fix Windows icon

### DIFF
--- a/blackpaint/src/index.ts
+++ b/blackpaint/src/index.ts
@@ -16,7 +16,14 @@ if (require('electron-squirrel-startup')) {
 
 const createWindow = (): void => {
   // Create the browser window.
-  const iconPath = path.join(app.getAppPath(), 'assets', 'e-logo.png');
+  const iconFilename =
+    process.platform === 'win32'
+      ? 'e-logo.ico'
+      : process.platform === 'darwin'
+        ? 'e-logo.icns'
+        : 'e-logo.png';
+
+  const iconPath = path.join(app.getAppPath(), 'assets', iconFilename);
   const icon = nativeImage.createFromPath(iconPath);
 
   const mainWindow = new BrowserWindow({


### PR DESCRIPTION
## Summary
- pick icon based on platform to preserve rounded corners

## Testing
- `npm test` in `taintedpaint`
- `npm run lint` in `blackpaint` *(fails: ESLint couldn't find eslint.config)*

------
https://chatgpt.com/codex/tasks/task_e_687fb408c288832da4ecd3c37a5b872d