### PR TITLE
Add Outsourcing column

### DIFF
--- a/taintedpaint/components/SearchDialog.tsx
+++ b/taintedpaint/components/SearchDialog.tsx
@@ -152,7 +152,7 @@ export default function SearchDialog({ isOpen, onClose, onTaskSelect }: SearchDi
                   </div>
                   <div className="flex-1 min-w-0">
                     <h3 className="text-sm font-semibold text-gray-800 truncate">
-                      {['sheet', 'approval', 'program', 'operate', 'polish', 'spray', 'inspect', 'ship', 'archive2'].includes(task.columnId)
+                      {['sheet', 'approval', 'outsourcing', 'program', 'operate', 'polish', 'spray', 'inspect', 'ship', 'archive2'].includes(task.columnId)
                         ? task.ynmxId || `${task.customerName} - ${task.representative}`
                         : `${task.customerName} - ${task.representative}`}
                     </h3>

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -30,6 +30,7 @@ export default function KanbanBoard() {
     send: 'bg-teal-500',
     sheet: 'bg-orange-500',
     approval: 'bg-yellow-500',
+    outsourcing: 'bg-sky-500',
     program: 'bg-indigo-500',
     operate: 'bg-cyan-500',
     polish: 'bg-pink-500',
@@ -220,7 +221,7 @@ export default function KanbanBoard() {
   const allTasksForSearch = useMemo(() => Object.values(tasks), [tasks]);
   const visibleColumns = useMemo(() => {
     if (viewMode === 'production') {
-      return columns.filter(c => ['approval', 'program', 'operate', 'polish', 'spray', 'inspect', 'ship', 'archive2'].includes(c.id))
+      return columns.filter(c => ['approval', 'outsourcing', 'program', 'operate', 'polish', 'spray', 'inspect', 'ship', 'archive2'].includes(c.id))
     }
     return columns
   }, [viewMode, columns])

--- a/taintedpaint/lib/baseColumns.ts
+++ b/taintedpaint/lib/baseColumns.ts
@@ -12,6 +12,7 @@ export const baseColumns: Column[] = [
   { id: "archive",     title: "报价归档",   taskIds: [] },
   { id: "sheet",       title: "制单",   taskIds: [] },
   { id: "approval",    title: "审批",   taskIds: [] },
+  { id: "outsourcing", title: "外协",   taskIds: [] },
   { id: "program",     title: "编程",   taskIds: [] },
   { id: "operate",     title: "操机",   taskIds: [] },
   { id: "polish",      title: "打磨",   taskIds: [] },

--- a/taintedpaint/public/storage/metadata.json
+++ b/taintedpaint/public/storage/metadata.json
@@ -62,6 +62,11 @@
       ]
     },
     {
+      "id": "outsourcing",
+      "title": "外协",
+      "taskIds": []
+    },
+    {
       "id": "program",
       "title": "编程",
       "taskIds": [


### PR DESCRIPTION
## Summary
- add a new column `外协` in the base columns
- show the new column on kanban board with a color tag and in production filters
- update search dialog logic to recognise `外协`
- include `外协` column in stored metadata

## Testing
- `npm test --prefix taintedpaint`
- `npm run lint --prefix taintedpaint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68808c45f04c832db212475271987fda