### PR TITLE
Replace Eldaline with Estara

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains two parts:
 
 - `taintedpaint` – the Next.js web app.
-- `blackpaint` – the Electron wrapper named **Eldaline**.
+- `blackpaint` – the Electron wrapper named **Estara**.
 
 Two Electron builds can be produced:
 
@@ -53,7 +53,7 @@ The project is split into two directories:
 
 - **taintedpaint** – a Next.js application that renders the Kanban board and REST
   API endpoints.
-- **blackpaint** – an Electron shell (called *Eldaline*) which loads the web app
+- **blackpaint** – an Electron shell (called *Estara*) which loads the web app
   and packages it as a desktop application.
 
 ### Data flow

--- a/blackpaint/README.md
+++ b/blackpaint/README.md
@@ -1,4 +1,4 @@
-# Eldaline (Blackpaint)
+# Estara (Blackpaint)
 
 This folder contains the Electron wrapper for the `taintedpaint` web
 application. Two distributable versions exist:

--- a/blackpaint/forge.config.ts
+++ b/blackpaint/forge.config.ts
@@ -25,13 +25,13 @@ const config: ForgeConfig = {
   rebuildConfig: {},
   makers: [
     new MakerSquirrel({
-      name: 'eldaline',
+      name: 'estara',
       setupIcon: path.join(__dirname, 'assets', 'e-logo.ico'),
       // Provide the icon URL so Squirrel creates shortcuts with
       // the custom icon instead of the default square icon.
       iconUrl: `file://${path.resolve(__dirname, 'assets', 'e-logo.ico')}`,
-      setupExe: 'EldalineSetup.exe',
-      exe: 'Eldaline.exe',
+      setupExe: 'EstaraSetup.exe',
+      exe: 'Estara.exe',
     }),
     new MakerZIP({}, ['darwin']),
     new MakerRpm({}),

--- a/blackpaint/package-lock.json
+++ b/blackpaint/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "eldaline",
+  "name": "estara",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "eldaline",
+      "name": "estara",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/blackpaint/package.json
+++ b/blackpaint/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "eldaline",
-  "productName": "Eldaline",
+  "name": "estara",
+  "productName": "Estara",
   "version": "1.0.0",
   "description": "My Electron application description",
   "main": ".webpack/main",

--- a/blackpaint/src/index.html
+++ b/blackpaint/src/index.html
@@ -3,7 +3,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>Eldaline Kanban</title>
+    <title>Estara Kanban</title>
   </head>
   <body>
     <!-- This is where our React app will live -->

--- a/taintedpaint/app/layout.tsx
+++ b/taintedpaint/app/layout.tsx
@@ -13,8 +13,8 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Eldaline",
-  description: "Eldaline Kanban board",
+  title: "Estara",
+  description: "Estara Kanban board",
 };
 
 export default function RootLayout({

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -231,7 +231,7 @@ export default function KanbanBoard() {
       <header className="px-6 py-4 bg-white/90 backdrop-blur-sm sticky top-0 z-30 border-b border-gray-200/80">
         <div className="flex items-center justify-between">
           <div className="flex items-baseline gap-2">
-            <h1 className="text-xl font-medium text-gray-900 tracking-tight">Eldaline</h1>
+            <h1 className="text-xl font-medium text-gray-900 tracking-tight">Estara</h1>
             <span className="text-sm text-gray-500 font-normal">项目看板</span>
           </div>
 


### PR DESCRIPTION
## Summary
- rename Eldaline to Estara across the project

## Testing
- `npm test` in `taintedpaint`
- `npm test` in `blackpaint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68808fda59a4832db7db2432bccf79c2