### PR TITLE
Add editable notes field

### DIFF
--- a/taintedpaint/app/api/jobs/[taskId]/update/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/update/route.ts
@@ -8,8 +8,11 @@ export async function PATCH(
 ) {
   const { taskId } = params;
   try {
-    const { deliveryDate } = await req.json();
-    if (typeof deliveryDate !== 'string') {
+    const { deliveryDate, notes } = await req.json();
+    if (deliveryDate !== undefined && typeof deliveryDate !== 'string') {
+      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+    }
+    if (notes !== undefined && typeof notes !== 'string') {
       return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
     }
 
@@ -17,7 +20,8 @@ export async function PATCH(
     await updateBoardData(async data => {
       const t = data.tasks[taskId];
       if (!t) throw new Error('Task not found');
-      t.deliveryDate = deliveryDate;
+      if (typeof deliveryDate === 'string') t.deliveryDate = deliveryDate;
+      if (typeof notes === 'string') t.notes = notes;
       updatedTask = t;
     });
 

--- a/taintedpaint/components/ui/textarea.tsx
+++ b/taintedpaint/components/ui/textarea.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -371,6 +371,9 @@ export default function KanbanBoard() {
                                   ? `交期: ${task.deliveryDate}`
                                   : `询价日期: ${task.inquiryDate}`}
                               </p>
+                              <p className="text-xs text-gray-400 mt-0.5 truncate">
+                                {task.notes || '无备注'}
+                              </p>
                             </div>
                           </div>
                         </Card>
@@ -435,6 +438,9 @@ export default function KanbanBoard() {
                             {task.deliveryDate
                               ? `交期: ${task.deliveryDate}`
                               : `询价日期: ${task.inquiryDate}`}
+                          </p>
+                          <p className="text-xs text-gray-400 mt-0.5 truncate">
+                            {task.notes || '无备注'}
                           </p>
                         </div>
                       </div>


### PR DESCRIPTION
## Summary
- add a reusable `Textarea` UI component
- allow editing notes from the drawer and always show the notes section
- expose notes on Kanban cards
- support notes updates in the API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68809c94553c832db0ecdd6135a23ef7