### PR TITLE
Fix encoded filenames when syncing tasks

### DIFF
--- a/taintedpaint/app/api/jobs/[taskId]/delete-file/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/delete-file/route.ts
@@ -4,6 +4,7 @@ import path from "path";
 import type { BoardData } from "@/types";
 import { updateBoardData } from "@/lib/boardDataStore";
 import { sanitizeRelativePath } from "@/lib/pathUtils.mjs";
+import { decodeUnderscoreHex } from "@/lib/underscoreHex";
 
 // --- Path Definitions ---
 const STORAGE_DIR = path.join(process.cwd(), "public", "storage");
@@ -22,7 +23,8 @@ export async function POST(
 
   try {
     const body = await req.json();
-    const { filename } = body; // treat as relative path
+    const rawFilename = body.filename; // treat as relative path
+    const filename = rawFilename ? decodeUnderscoreHex(rawFilename) : rawFilename;
 
     if (!filename) {
       return NextResponse.json({ error: "Filename is required" }, { status: 400 });

--- a/taintedpaint/app/api/jobs/[taskId]/files/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/files/route.ts
@@ -3,6 +3,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { promises as fs } from "fs";
 import path from "path";
+import { decodeUnderscoreHex } from "@/lib/underscoreHex";
 
 const TASKS_STORAGE_DIR = path.join(process.cwd(), "public", "storage", "tasks");
 
@@ -30,6 +31,8 @@ async function getFilesRecursively(directory: string, basePath: string, baseUrl:
       fileList = fileList.concat(subFiles);
     } else if (entry.isFile()) {
       const relativePath = path.relative(basePath, fullPath);
+      const decodedRelPath = decodeUnderscoreHex(relativePath);
+      const decodedName = decodeUnderscoreHex(entry.name);
       const stats = await fs.stat(fullPath);
 
       // --- PROACTIVE IMPROVEMENT ---
@@ -41,8 +44,8 @@ async function getFilesRecursively(directory: string, basePath: string, baseUrl:
       const url = `${baseUrl}/storage/tasks/${path.basename(basePath)}/${encodedRelativePath}`;
 
       fileList.push({
-        filename: entry.name,
-        relativePath: relativePath,
+        filename: decodedName,
+        relativePath: decodedRelPath,
         url: url,
         mtimeMs: stats.mtimeMs,
       });

--- a/taintedpaint/app/api/jobs/[taskId]/upload/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/upload/route.ts
@@ -5,6 +5,7 @@ import { promises as fs } from "fs";
 import path from "path";
 import type { BoardData } from "@/types";
 import { updateBoardData } from "@/lib/boardDataStore";
+import { decodeUnderscoreHex } from "@/lib/underscoreHex";
 
 // --- Path Definitions ---
 const STORAGE_DIR = path.join(process.cwd(), "public", "storage");
@@ -37,7 +38,8 @@ export async function POST(
 
     for (let i = 0; i < files.length; i++) {
       const file = files[i];
-      const relPath = paths[i] || file.name;
+      const relPathRaw = paths[i] || file.name;
+      const relPath = decodeUnderscoreHex(relPathRaw);
 
       if (path.isAbsolute(relPath)) {
         return NextResponse.json({ error: "Paths must be relative" }, { status: 400 });

--- a/taintedpaint/lib/underscoreHex.ts
+++ b/taintedpaint/lib/underscoreHex.ts
@@ -1,0 +1,10 @@
+export function decodeUnderscoreHex(input: string): string {
+  return input.replace(/(?:_[0-9A-Fa-f]{2})+/g, seq => {
+    const hex = seq.replace(/_/g, '');
+    try {
+      return Buffer.from(hex, 'hex').toString('utf8');
+    } catch {
+      return seq;
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add `decodeUnderscoreHex` helper to convert `_E6_89...` segments back to UTF-8 characters
- decode filenames and paths in job file APIs so uploaded files keep their original names

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6880dbf30e08832da84746a2becba1e5