### PR TITLE
Fix download errors on Windows and document issue

### DIFF
--- a/ISSUES.MD
+++ b/ISSUES.MD
@@ -1,0 +1,19 @@
+# File Sync Error When Downloading Job Folder
+
+## Architecture Overview
+- **taintedpaint** provides the Next.js web interface and REST API. Job files are saved under `public/storage/tasks`. Metadata is tracked in `public/storage/metadata.json`.
+- **blackpaint** is the Electron wrapper (Estara). When the Kanban drawer's "Open" button is used, the Electron main process downloads the job's files to the user's `Downloads` directory and starts a bidirectional sync (`startBidirectionalSync` in `blackpaint/src/sync.ts`).
+
+## Problem Description
+During testing a job folder `YNMX-25-7-15-208` was uploaded successfully. The job appeared in 建单, but clicking **Open** in the Kanban drawer caused a popup:
+```
+下载失败: Error invoking remote method 'download-and-open-task-folder':
+Error: ENOENT: no such file or directory,
+open 'd:\Downloads\ewf_fwe\YNMX-25-7-15-208\QG2507040003 005腕部-吴东东 2025.07.07\0111□□-17 按钮 01.pdf'
+```
+Inspecting the local Downloads folder showed empty files.
+
+The server stores uploaded filenames exactly as received. Some names contain characters that are invalid on Windows (`?`, `*`, `:` etc.). `download-and-open-task-folder` only sanitized the root folder name, so when the Electron app attempted to create files with disallowed characters Windows refused, triggering an `ENOENT` error and leaving zero‑byte files.
+
+## Resolution
+`blackpaint/src/index.ts` now sanitizes every component of each downloaded file path. On Windows, characters `\/:*?"<>|` and trailing spaces or dots are replaced with underscores before writing. This prevents filesystem errors when jobs include filenames with Windows‑reserved characters.

--- a/blackpaint/src/index.ts
+++ b/blackpaint/src/index.ts
@@ -70,8 +70,20 @@ app.on('ready', () => {
         const destinationFolder = path.join(app.getPath('downloads'), safeFolderName);
         await fs.mkdir(destinationFolder, { recursive: true });
 
+        const sanitizePart = (p: string) =>
+          process.platform === 'win32'
+            ? p.replace(/[\\/:*?"<>|]/g, '_').replace(/[. ]+$/, '')
+            : p;
+
+        const sanitizeRelPath = (relPath: string) =>
+          relPath
+            .split(/[/\\]/)
+            .map((part) => sanitizePart(part))
+            .join(path.sep);
+
         const downloadPromises = filesToDownload.map(async (file) => {
-          const localFilePath = path.join(destinationFolder, file.relativePath);
+          const sanitizedPath = sanitizeRelPath(file.relativePath);
+          const localFilePath = path.join(destinationFolder, sanitizedPath);
           await fs.mkdir(path.dirname(localFilePath), { recursive: true });
 
           const response = await axios.get<ArrayBuffer>(file.url, {


### PR DESCRIPTION
## Summary
- sanitize every downloaded file path on Windows
- document the file sync failure and fix in `ISSUES.MD`

## Testing
- `npm test` in `taintedpaint`
- `npm run lint` *(fails: asks for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6880eea37974832d9ab9c69419594c57