### PR TITLE
Fix mis-decoding of underscore sequences in API

### DIFF
--- a/ISSUES.MD
+++ b/ISSUES.MD
@@ -17,3 +17,14 @@ The server stores uploaded filenames exactly as received. Some names contain cha
 
 ## Resolution
 `blackpaint/src/index.ts` now sanitizes every component of each downloaded file path. On Windows, characters `\/:*?"<>|` and trailing spaces or dots are replaced with underscores before writing. This prevents filesystem errors when jobs include filenames with Windows‑reserved characters.
+
+## Ongoing Issue: Hex Decoding of Underscore Sequences
+Another bug surfaced after the above fix. The server-side API routes apply `decodeUnderscoreHex` to uploaded filenames and paths. This helper interprets any sequence like `_E5_B9_BF` as hexadecimal bytes and decodes them. Legitimate filenames containing underscore-digit patterns (e.g. `0111_03_04-17 拨钮 01.PDF`) are therefore mangled into control characters when saved on the server. When Estara later downloads the job it requests these garbled names, producing `ENOENT` errors such as:
+
+```
+下载失败: Error invoking remote method 'download-and-open-task-folder':
+Error: ENOENT: no such file or directory,
+open 'd:\Downloads\X0 - X0\YNMX-25-7-15-208\QG2507040003 200S腕部-吴东东 2025.07.07\0111□□-17 数组 01.pdf'
+```
+
+The fix removes `decodeUnderscoreHex` from all API routes. Filenames are now stored exactly as uploaded, avoiding accidental conversion of underscores followed by digits.

--- a/taintedpaint/app/api/jobs/[taskId]/delete-file/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/delete-file/route.ts
@@ -4,7 +4,6 @@ import path from "path";
 import type { BoardData } from "@/types";
 import { updateBoardData } from "@/lib/boardDataStore";
 import { sanitizeRelativePath } from "@/lib/pathUtils.mjs";
-import { decodeUnderscoreHex } from "@/lib/underscoreHex";
 
 // --- Path Definitions ---
 const STORAGE_DIR = path.join(process.cwd(), "public", "storage");
@@ -24,7 +23,7 @@ export async function POST(
   try {
     const body = await req.json();
     const rawFilename = body.filename; // treat as relative path
-    const filename = rawFilename ? decodeUnderscoreHex(rawFilename) : rawFilename;
+    const filename = rawFilename;
 
     if (!filename) {
       return NextResponse.json({ error: "Filename is required" }, { status: 400 });

--- a/taintedpaint/app/api/jobs/[taskId]/files/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/files/route.ts
@@ -3,7 +3,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { promises as fs } from "fs";
 import path from "path";
-import { decodeUnderscoreHex } from "@/lib/underscoreHex";
 
 const TASKS_STORAGE_DIR = path.join(process.cwd(), "public", "storage", "tasks");
 
@@ -31,8 +30,6 @@ async function getFilesRecursively(directory: string, basePath: string, baseUrl:
       fileList = fileList.concat(subFiles);
     } else if (entry.isFile()) {
       const relativePath = path.relative(basePath, fullPath);
-      const decodedRelPath = decodeUnderscoreHex(relativePath);
-      const decodedName = decodeUnderscoreHex(entry.name);
       const stats = await fs.stat(fullPath);
 
       // --- PROACTIVE IMPROVEMENT ---
@@ -44,9 +41,9 @@ async function getFilesRecursively(directory: string, basePath: string, baseUrl:
       const url = `${baseUrl}/storage/tasks/${path.basename(basePath)}/${encodedRelativePath}`;
 
       fileList.push({
-        filename: decodedName,
-        relativePath: decodedRelPath,
-        url: url,
+        filename: entry.name,
+        relativePath,
+        url,
         mtimeMs: stats.mtimeMs,
       });
     }

--- a/taintedpaint/app/api/jobs/[taskId]/update-file/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/update-file/route.ts
@@ -6,7 +6,6 @@ import path from "path";
 import type { BoardData } from "@/types";
 import { updateBoardData } from "@/lib/boardDataStore";
 import { sanitizeRelativePath } from "@/lib/pathUtils.mjs";
-import { decodeUnderscoreHex } from "@/lib/underscoreHex";
 
 const STORAGE_DIR = path.join(process.cwd(), "public", "storage");
 const TASKS_STORAGE_DIR = path.join(STORAGE_DIR, "tasks");
@@ -26,8 +25,8 @@ export async function POST(
     const newFile = formData.get("newFile") as File | null;
     const oldFilenameRaw = formData.get("oldFilename") as string | null;
     const relativePathRaw = formData.get("relativePath") as string | null;
-    const oldFilename = oldFilenameRaw ? decodeUnderscoreHex(oldFilenameRaw) : null;
-    const relativePath = relativePathRaw ? decodeUnderscoreHex(relativePathRaw) : null;
+    const oldFilename = oldFilenameRaw || null;
+    const relativePath = relativePathRaw || null;
     if (!newFile || !oldFilename) {
       return NextResponse.json({ error: "Missing newFile or oldFilename" }, { status: 400 });
     }
@@ -45,8 +44,7 @@ export async function POST(
     const oldFilePath = path.join(taskDirectoryPath, safeRelativePath || oldFilename);
 
     // --- FIX: Use a less restrictive regex that allows Unicode characters ---
-    const decodedName = decodeUnderscoreHex(newFile.name);
-    const sanitizedNewFilename = decodedName.replace(/[\\/:*?"<>|]/g, '_');
+    const sanitizedNewFilename = newFile.name.replace(/[\\/:*?"<>|]/g, '_');
     // ----------------------------------------------------------------------
     const newFilePath = path.join(
       taskDirectoryPath,

--- a/taintedpaint/app/api/jobs/[taskId]/upload/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/upload/route.ts
@@ -5,7 +5,6 @@ import { promises as fs } from "fs";
 import path from "path";
 import type { BoardData } from "@/types";
 import { updateBoardData } from "@/lib/boardDataStore";
-import { decodeUnderscoreHex } from "@/lib/underscoreHex";
 
 // --- Path Definitions ---
 const STORAGE_DIR = path.join(process.cwd(), "public", "storage");
@@ -39,7 +38,7 @@ export async function POST(
     for (let i = 0; i < files.length; i++) {
       const file = files[i];
       const relPathRaw = paths[i] || file.name;
-      const relPath = decodeUnderscoreHex(relPathRaw);
+      const relPath = relPathRaw;
 
       if (path.isAbsolute(relPath)) {
         return NextResponse.json({ error: "Paths must be relative" }, { status: 400 });


### PR DESCRIPTION
## Summary
- remove decodeUnderscoreHex usage from all job API routes
- document the underscore decoding issue in `ISSUES.MD`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880f5849d2c832db2f0451a3a1f16be