### PR TITLE
Fix nested folder uploads

### DIFF
--- a/issues-nested-folders-sync.md
+++ b/issues-nested-folders-sync.md
@@ -1,0 +1,14 @@
+# Nested Folders Reappear in Downloads
+
+## Architecture and Workflow Overview
+- **taintedpaint** serves as the Next.js web interface and provides REST API routes for file management. Uploaded jobs are stored under `public/storage/tasks/{taskId}`.
+- **blackpaint (Estara)** is the Electron shell. When the user clicks *Open* in the Kanban drawer it downloads all job files to `~/Downloads/{folderName}` and starts a bidirectional sync via `startBidirectionalSync`.
+
+## Problem
+When uploading a folder through the web interface each file is sent with its `webkitRelativePath`. This path includes the root folder name. The server stored the files exactly as received (e.g. `task-123/partA.pdf`). When Estara later downloaded the job it also created a folder named after the job (e.g. `YNMX-001`). Because the stored paths already contained the top level directory, the downloaded folder ended up containing another copy of the root (e.g. `YNMX-001/task-123/partA.pdf`). If the user deleted the extra subfolder locally it was recreated on the next sync because the server kept that prefix.
+
+## Fix
+Strip the uploaded root folder name from each file path on the server. The `POST /api/jobs` route now removes the `folderName` prefix from every `filePaths` entry before saving. Newly created tasks therefore store files directly under `public/storage/tasks/{taskId}` without the extra subdirectory.
+
+## Result
+Opening a job in Estara now downloads files directly into the job folder without nesting. Deleting local folders no longer results in them reappearing from the server.

--- a/taintedpaint/app/api/jobs/route.ts
+++ b/taintedpaint/app/api/jobs/route.ts
@@ -60,11 +60,20 @@ export async function POST(req: NextRequest) {
     await fs.mkdir(taskDirectoryPath, { recursive: true });
 
     // This file saving logic is still correct and necessary to build the directory
+    // strip the uploaded root folder name from each path
+    const rootPrefix = folderName.replace(/[/\\]+$/, '') + '/';
+
     for (let i = 0; i < files.length; i++) {
       const file = files[i];
-      const relativePath = filePaths[i];
-      const safeRelativePath = path.normalize(relativePath).replace(/^(\.\.[\/\\])+/, '');
-      if (safeRelativePath.includes('..')) continue; 
+      const rawPath = filePaths[i];
+      // remove the leading folderName/ if present
+      const relativePath = rawPath.startsWith(rootPrefix)
+        ? rawPath.slice(rootPrefix.length)
+        : rawPath;
+      const safeRelativePath = path
+        .normalize(relativePath)
+        .replace(/^(\.\.[\/\\])+/, '');
+      if (safeRelativePath.includes('..')) continue;
       const destinationPath = path.join(taskDirectoryPath, safeRelativePath);
       await fs.mkdir(path.dirname(destinationPath), { recursive: true });
       const buf = Buffer.from(await file.arrayBuffer());


### PR DESCRIPTION
## Summary
- document nested folders issue
- strip root folder from uploaded paths in `POST /api/jobs`

## Testing
- `npm test` in taintedpaint
- `npm test` in blackpaint *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6880fec243a8832d9ea2681ec41052fb