### PR TITLE
Rename Estara data folder

### DIFF
--- a/blackpaint/src/index.ts
+++ b/blackpaint/src/index.ts
@@ -67,7 +67,7 @@ app.on('ready', () => {
     ) => {
       try {
         const safeFolderName = folderName.replace(/[\\/:*?"<>|]/g, '').trim();
-        const rootDir = path.join(app.getPath('desktop'), 'Estera 数据库');
+        const rootDir = path.join(app.getPath('desktop'), 'Estara 数据');
         await fs.mkdir(rootDir, { recursive: true });
         const destinationFolder = path.join(rootDir, safeFolderName);
         await fs.mkdir(destinationFolder, { recursive: true });

--- a/file-sync.md
+++ b/file-sync.md
@@ -14,7 +14,7 @@ The project consists of two parts:
 1. In the web UI, the Kanban drawer calls `window.electronAPI.downloadAndOpenTaskFolder()` with the task ID, a folder name and a list of files to download.
 2. `blackpaint/src/index.ts` registers an IPC handler for `download-and-open-task-folder`. The handler:
    - Sanitises the folder name.
-   - Creates a root directory on the user's desktop named **`Estera 数据库`**.
+   - Creates a root directory on the user's desktop named **`Estara 数据`**.
    - Creates a subfolder for the selected task beneath this root.
    - Downloads each file from the provided URLs into the task folder.
    - Opens the folder using the OS file manager.
@@ -36,10 +36,10 @@ Each active sync keeps its own pending upload queue to retry failed uploads with
 
 ## Storage Location
 
-Originally task folders were downloaded under the user's **Downloads** directory. The Electron client now uses the Desktop instead, placing all task folders inside a single directory named **`Estera 数据库`**. For example:
+Originally task folders were downloaded under the user's **Downloads** directory. The Electron client now uses the Desktop instead, placing all task folders inside a single directory named **`Estara 数据`**. For example:
 
 ```
-~/Desktop/Estera 数据库/<Task Folder>
+~/Desktop/Estara 数据/<Task Folder>
 ```
 
 This path is created automatically if it does not exist. All synchronization still works the same—files within each task folder are kept up to date with the server in both directions.


### PR DESCRIPTION
## Summary
- rename the folder used for local task storage
- update documentation referencing the folder name

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run test` in `taintedpaint`
- `npm run lint` in `taintedpaint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881194c7d9c832db197e3fd8a3cbf4c