### PR TITLE
Add short task identifiers for folder names

### DIFF
--- a/taintedpaint/components/KanbanDrawer.tsx
+++ b/taintedpaint/components/KanbanDrawer.tsx
@@ -8,6 +8,7 @@ import { X, CalendarDays, MessageSquare, Folder, Pencil } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
+import { getFolderName, getShortId } from "@/lib/taskUtils";
 
 interface KanbanDrawerProps {
   isOpen: boolean;
@@ -73,7 +74,7 @@ export default function KanbanDrawer({
         alert("此任务没有可下载的文件。");
         return;
       }
-      const folderName = task.ynmxId || `${task.customerName} - ${task.representative}`;
+      const folderName = getFolderName(task);
       await electronAPI.downloadAndOpenTaskFolder(task.id, folderName, filesToDownload);
     } catch (err: any) {
       console.error("Download and open failed:", err);
@@ -149,9 +150,9 @@ export default function KanbanDrawer({
               {viewMode === 'business' && (
                 <p className="text-[15px] text-black/60 truncate">{task.representative}</p>
               )}
-              {viewMode === 'business' && task.ynmxId && (
+              {viewMode === 'business' && (
                 <span className="text-[13px] font-medium text-black/50 bg-black/5 px-2 py-0.5 rounded-full">
-                  {task.ynmxId}
+                  {task.ynmxId || `#${getShortId(task)}`}
                 </span>
               )}
               {columnTitle && (

--- a/taintedpaint/components/SearchDialog.tsx
+++ b/taintedpaint/components/SearchDialog.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { Search, Loader2, FileText, X } from "lucide-react";
 import type { Task } from "@/types";
+import { getDisplayName, getShortId } from "@/lib/taskUtils";
 
 interface SearchDialogProps {
   isOpen: boolean;
@@ -154,8 +155,8 @@ export default function SearchDialog({ isOpen, onClose, onTaskSelect }: SearchDi
                   <div className="flex-1 min-w-0">
                     <h3 className="text-sm font-semibold text-gray-800 truncate">
                       {['sheet', 'approval', 'outsourcing', 'program', 'operate', 'polish', 'spray', 'inspect', 'ship', 'archive2'].includes(task.columnId)
-                        ? task.ynmxId || `${task.customerName} - ${task.representative}`
-                        : `${task.customerName} - ${task.representative}`}
+                        ? getDisplayName(task)
+                        : `${task.customerName} - ${task.representative} #${getShortId(task)}`}
                     </h3>
                     <p className="text-xs text-gray-600">{task.deliveryDate || task.inquiryDate}</p>
                   </div>

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -10,6 +10,7 @@ import Link from "next/link"
 import { baseColumns, START_COLUMN_ID } from "@/lib/baseColumns"
 import KanbanDrawer from "@/components/KanbanDrawer"
 import SearchDialog from "@/components/SearchDialog"
+import { getDisplayName, getShortId } from "@/lib/taskUtils"
 
 export default function KanbanBoard() {
   const restricted =
@@ -91,9 +92,9 @@ export default function KanbanBoard() {
 
   const getTaskDisplayName = (task: Task) => {
     if (viewMode === 'production') {
-      return task.ynmxId || `${task.customerName} - ${task.representative}`;
+      return getDisplayName(task);
     }
-    return `${task.customerName} - ${task.representative}`;
+    return `${task.customerName} - ${task.representative} #${getShortId(task)}`;
   };
 
   const mergeWithSkeleton = (saved: Column[]): Column[] => {
@@ -357,9 +358,7 @@ export default function KanbanBoard() {
                                     {task.customerName}
                                   </h3>
                                   <p className="text-xs text-gray-500">{task.representative}</p>
-                                  {task.ynmxId && (
-                                    <p className="text-xs text-gray-400">{task.ynmxId}</p>
-                                  )}
+                                  <p className="text-xs text-gray-400">{task.ynmxId || `#${getShortId(task)}`}</p>
                                 </>
                               ) : (
                                 <h3 className="text-sm font-medium text-gray-800 leading-tight group-hover:text-gray-900 transition-colors">
@@ -427,9 +426,7 @@ export default function KanbanBoard() {
                                 {task.customerName}
                               </h3>
                               <p className="text-xs text-gray-500">{task.representative}</p>
-                              {task.ynmxId && (
-                                <p className="text-xs text-gray-400">{task.ynmxId}</p>
-                              )}
+                              <p className="text-xs text-gray-400">{task.ynmxId || `#${getShortId(task)}`}</p>
                             </>
                           ) : (
                             <h3 className="text-sm font-medium text-gray-800 leading-tight group-hover:text-gray-900 transition-colors">

--- a/taintedpaint/lib/taskUtils.ts
+++ b/taintedpaint/lib/taskUtils.ts
@@ -1,0 +1,15 @@
+import type { Task } from '@/types';
+
+export function getShortId(task: Task): string {
+  return task.id.slice(-4);
+}
+
+export function getFolderName(task: Task): string {
+  if (task.ynmxId) return task.ynmxId;
+  const short = getShortId(task);
+  return `${task.customerName} - ${task.representative} #${short}`;
+}
+
+export function getDisplayName(task: Task): string {
+  return task.ynmxId || `${task.customerName} - ${task.representative} #${getShortId(task)}`;
+}


### PR DESCRIPTION
## Summary
- ensure unique desktop folders by appending a short id
- display the short id on Kanban cards and drawer header
- use consistent display logic in search results

## Testing
- `npm test` in `taintedpaint`
- `npm test` in `blackpaint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688125ea6a48832d895396333db87d79