### PR TITLE
Merge polish and spray columns

### DIFF
--- a/taintedpaint/components/SearchDialog.tsx
+++ b/taintedpaint/components/SearchDialog.tsx
@@ -153,7 +153,7 @@ export default function SearchDialog({ isOpen, onClose, onTaskSelect }: SearchDi
                   </div>
                   <div className="flex-1 min-w-0">
                     <h3 className="text-sm font-semibold text-gray-800 truncate">
-                      {['sheet', 'approval', 'outsourcing', 'program', 'operate', 'polish', 'spray', 'inspect', 'ship', 'archive2'].includes(task.columnId)
+                      {['sheet', 'approval', 'outsourcing', 'program', 'operate', 'assembly', 'surface', 'inspect', 'ship', 'archive2'].includes(task.columnId)
                         ? task.ynmxId || `${task.customerName} - ${task.representative}`
                         : `${task.customerName} - ${task.representative}`}
                     </h3>

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -33,8 +33,8 @@ export default function KanbanBoard() {
     outsourcing: 'bg-sky-500',
     program: 'bg-indigo-500',
     operate: 'bg-cyan-500',
-    polish: 'bg-pink-500',
-    spray: 'bg-rose-500',
+    assembly: 'bg-amber-500',
+    surface: 'bg-rose-500',
     inspect: 'bg-lime-500',
     ship: 'bg-green-500',
     archive: 'bg-gray-400',
@@ -221,7 +221,7 @@ export default function KanbanBoard() {
   const allTasksForSearch = useMemo(() => Object.values(tasks), [tasks]);
   const visibleColumns = useMemo(() => {
     if (viewMode === 'production') {
-      return columns.filter(c => ['approval', 'outsourcing', 'program', 'operate', 'polish', 'spray', 'inspect', 'ship', 'archive2'].includes(c.id))
+      return columns.filter(c => ['approval', 'outsourcing', 'program', 'operate', 'assembly', 'surface', 'inspect', 'ship', 'archive2'].includes(c.id))
     }
     return columns
   }, [viewMode, columns])

--- a/taintedpaint/lib/baseColumns.ts
+++ b/taintedpaint/lib/baseColumns.ts
@@ -14,9 +14,9 @@ export const baseColumns: Column[] = [
   { id: "approval",    title: "审批",   taskIds: [] },
   { id: "outsourcing", title: "外协",   taskIds: [] },
   { id: "program",     title: "编程",   taskIds: [] },
-  { id: "operate",     title: "操机",   taskIds: [] },
-  { id: "polish",      title: "打磨",   taskIds: [] },
-  { id: "spray",       title: "喷涂",   taskIds: [] },
+  { id: "operate",     title: "操机 - 手工",   taskIds: [] },
+  { id: "assembly",    title: "装配",   taskIds: [] },
+  { id: "surface",     title: "表面处理",   taskIds: [] },
   { id: "inspect",     title: "检验",   taskIds: [] },
   { id: "ship",        title: "出货",   taskIds: [] },
   { id: "archive2",    title: "完成归档",   taskIds: [] }

--- a/taintedpaint/public/storage/metadata.json
+++ b/taintedpaint/public/storage/metadata.json
@@ -75,17 +75,17 @@
     },
     {
       "id": "operate",
-      "title": "操机",
+      "title": "操机 - 手工",
       "taskIds": []
     },
     {
-      "id": "polish",
-      "title": "打磨",
+      "id": "assembly",
+      "title": "装配",
       "taskIds": []
     },
     {
-      "id": "spray",
-      "title": "喷涂",
+      "id": "surface",
+      "title": "表面处理",
       "taskIds": []
     },
     {


### PR DESCRIPTION
## Summary
- combine 打磨 and 喷涂 into a single 表面处理 column
- insert 装配 column after 操机 - 手工
- update color mapping and search logic
- adjust stored metadata

## Testing
- `cd taintedpaint && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881eaafa15c832dbcfbdb24cd8c053c