### PR TITLE
codex: avoid folder name collisions

### DIFF
--- a/issues-duplicate-folder-names.md
+++ b/issues-duplicate-folder-names.md
@@ -1,0 +1,14 @@
+# Duplicate Local Folder Names Before YNMX Assignment
+
+## Problem
+If multiple tasks are created for the same customer and representative before a YNMX ID is assigned, Estara would name each local folder using only `customerName - representative`. Opening more than one such task would map them to the exact same directory on the user's desktop. This risked files from different tasks mixing together or uploads going to the wrong job.
+
+## Solution
+`KanbanDrawer` now appends the unique task ID whenever a YNMX ID is not present:
+
+```ts
+const folderName =
+  task.ynmxId || `${task.customerName} - ${task.representative} - ${task.id}`;
+```
+
+Each job therefore downloads to a distinct path even when customer and representative are identical. Bidirectional sync continues per task ID so local and remote files remain separate.

--- a/taintedpaint/components/KanbanDrawer.tsx
+++ b/taintedpaint/components/KanbanDrawer.tsx
@@ -73,7 +73,8 @@ export default function KanbanDrawer({
         alert("此任务没有可下载的文件。");
         return;
       }
-      const folderName = task.ynmxId || `${task.customerName} - ${task.representative}`;
+      const folderName =
+        task.ynmxId || `${task.customerName} - ${task.representative} - ${task.id}`;
       await electronAPI.downloadAndOpenTaskFolder(task.id, folderName, filesToDownload);
     } catch (err: any) {
       console.error("Download and open failed:", err);


### PR DESCRIPTION
## Summary
- ensure unique local folder names when a job lacks YNMX ID
- document duplicate folder name issue

## Testing
- `npm test` in `taintedpaint`
- `npm test` in `blackpaint` *(fails: Missing script)*
- `npm run lint` in `blackpaint` *(fails: ESLint config not found)*
- `npm run lint` in `taintedpaint` *(fails: next not found)*
- `npx tsc -p tsconfig.json` in `taintedpaint` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68820f6aa668832dabbc6603ec5297e8