### PR TITLE
Explain sync behavior & verify task existence

### DIFF
--- a/relevant-issue-name.md
+++ b/relevant-issue-name.md
@@ -1,0 +1,17 @@
+# Storage Folder Reappears After Deletion
+
+## Architecture Overview
+- **taintedpaint** hosts the Next.js web app and REST API. Uploaded tasks are saved under `public/storage/tasks/<taskId>` and metadata lives in `public/storage/metadata.json`.
+- **blackpaint** is the Electron client (*Estara*). When a task is opened it downloads files locally and starts a bidirectional sync via `startBidirectionalSync` in `blackpaint/src/sync.ts`.
+
+## Why deleted server files return
+When the server's `/public/storage` directory is removed, any running Estara clients still think their tasks exist. The sync process lists files locally and uploads missing ones to the server every 10 seconds. The upload route (`app/api/jobs/[taskId]/upload/route.ts`) previously wrote files to disk before checking that the task was still present in `metadata.json`. As a result, clients recreated `/storage/tasks/<taskId>` even though the metadata file was gone.
+
+## Temporary metadata files
+`lib/boardDataStore.ts` writes updates using a lock file and a temporary path like `metadata.json.<uuid>.tmp` before renaming it to `metadata.json`.
+These temp files normally disappear instantly, but if the process crashes mid-write they may linger. They can be safely deleted.
+
+## Are these issues?
+- The reappearance of task folders without metadata can lead to orphaned files. The upload API now verifies the task exists using `readBoardData()` before accepting files.
+- Leftover temporary metadata files are harmless and only occur if a write is interrupted.
+

--- a/taintedpaint/app/api/jobs/[taskId]/upload/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/upload/route.ts
@@ -4,7 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { promises as fs } from "fs";
 import path from "path";
 import type { BoardData } from "@/types";
-import { updateBoardData } from "@/lib/boardDataStore";
+import { updateBoardData, readBoardData } from "@/lib/boardDataStore";
 
 // --- Path Definitions ---
 const STORAGE_DIR = path.join(process.cwd(), "public", "storage");
@@ -25,6 +25,11 @@ export async function POST(
     const formData = await req.formData();
     const files = formData.getAll("files") as File[];
     const paths = formData.getAll("paths") as string[];
+
+    const boardData = await readBoardData();
+    if (!boardData.tasks[taskId]) {
+      return NextResponse.json({ error: "Task not found" }, { status: 404 });
+    }
 
     if (!files || files.length === 0) {
       return NextResponse.json({ error: "No files provided" }, { status: 400 });


### PR DESCRIPTION
## Summary
- document why the `/storage` directory is recreated
- explain temp metadata files
- ensure upload route checks that the task exists before writing

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688223de7d34832db24e43b8ea7fda3e