### PR TITLE
Handle temp files and empty directory sync

### DIFF
--- a/issues-temp-files-and-empty-dirs.md
+++ b/issues-temp-files-and-empty-dirs.md
@@ -1,0 +1,18 @@
+# LCK/BAK Files and Missing Empty Directories
+
+## Architecture
+- **taintedpaint** runs the Next.js API. Task files live under `public/storage/tasks/<taskId>` and are listed through `/api/jobs/[taskId]/files`.
+- **blackpaint (Estara)** downloads a job's folder then keeps it in sync via `startBidirectionalSync` in `blackpaint/src/sync.ts`.
+
+## Problem
+While testing downloads on multiple machines the client began to receive extra files ending with `.lck` or `.bak`. These lock/backup files are created by CAD software when a user opens a drawing. Our sync logic uploaded them to the server where they were later downloaded by other clients. Additionally, empty subfolders that existed on the original machine did not appear after downloading a job on another computer.
+
+## Root Cause
+- `startBidirectionalSync` only ignored a few system files and uploaded every other file change. AutoCAD lock (`*.lck`) and backup (`*.bak`) files therefore propagated to the server.
+- The `/api/jobs/[taskId]/files` route only returned regular files. Because empty folders contain no files they were never listed and thus were not recreated when downloading.
+
+## Fix
+- Updated both the client sync logic and the server file listing to ignore `*.lck` and `*.bak` files.
+- Added new API routes `/api/jobs/[taskId]/create-dir` and `/api/jobs/[taskId]/delete-dir` so the client can explicitly sync directory creation and removal.
+- `startBidirectionalSync` now watches `addDir` and `unlinkDir` events. Directories reported by the server are recreated locally during sync so empty folders persist across machines.
+

--- a/taintedpaint/app/api/jobs/[taskId]/create-dir/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/create-dir/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { promises as fs } from 'fs'
+import path from 'path'
+import { sanitizeRelativePath } from '@/lib/pathUtils.mjs'
+
+const TASKS_STORAGE_DIR = path.join(process.cwd(), 'public', 'storage', 'tasks')
+
+export async function POST(req: NextRequest, { params }: { params: { taskId: string } }) {
+  const { taskId } = params
+  if (!taskId) return NextResponse.json({ error: 'Task ID is required' }, { status: 400 })
+
+  try {
+    const { relativePath } = await req.json()
+    if (!relativePath) {
+      return NextResponse.json({ error: 'relativePath required' }, { status: 400 })
+    }
+    let safeRel
+    try {
+      safeRel = sanitizeRelativePath(relativePath)
+    } catch {
+      return NextResponse.json({ error: 'Invalid path' }, { status: 400 })
+    }
+
+    const dirPath = path.join(TASKS_STORAGE_DIR, taskId, safeRel)
+    await fs.mkdir(dirPath, { recursive: true })
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    console.error('create-dir error', err)
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
+  }
+}

--- a/taintedpaint/app/api/jobs/[taskId]/delete-dir/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/delete-dir/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { promises as fs } from 'fs'
+import path from 'path'
+import { sanitizeRelativePath } from '@/lib/pathUtils.mjs'
+
+const TASKS_STORAGE_DIR = path.join(process.cwd(), 'public', 'storage', 'tasks')
+
+export async function POST(req: NextRequest, { params }: { params: { taskId: string } }) {
+  const { taskId } = params
+  if (!taskId) return NextResponse.json({ error: 'Task ID is required' }, { status: 400 })
+
+  try {
+    const { relativePath } = await req.json()
+    if (!relativePath) {
+      return NextResponse.json({ error: 'relativePath required' }, { status: 400 })
+    }
+    let safeRel
+    try {
+      safeRel = sanitizeRelativePath(relativePath)
+    } catch {
+      return NextResponse.json({ error: 'Invalid path' }, { status: 400 })
+    }
+
+    const dirPath = path.join(TASKS_STORAGE_DIR, taskId, safeRel)
+    try {
+      await fs.rmdir(dirPath)
+    } catch (err: any) {
+      if (err.code !== 'ENOENT') throw err
+    }
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    console.error('delete-dir error', err)
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- document how .lck/.bak files appeared and why empty folders vanished
- ignore `.lck` and `.bak` in sync logic and server file listing
- add server routes to create/delete directories
- sync directory creation and removal in `startBidirectionalSync`

## Testing
- `npm --prefix taintedpaint test`
- `npm --prefix blackpaint test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68835bb194e0832dbc28ac05f4973cbd