### PR TITLE
Fix invalid URL error when downloading jobs

### DIFF
--- a/issues-invalid-url-download.md
+++ b/issues-invalid-url-download.md
@@ -1,0 +1,22 @@
+# Download Fails with Invalid URL Error
+
+## Architecture Overview
+- **taintedpaint** hosts the Next.js API routes and serves uploaded files from `public/storage/tasks/{taskId}`.
+- **blackpaint** is the Electron client (Estara). The Kanban drawer calls `downloadAndOpenTaskFolder` which retrieves `/api/jobs/{taskId}/files`, downloads each entry and starts sync.
+
+## Problem
+After uploading a job, clicking **Open** in the drawer showed:
+
+```
+下载失败: Error invoking remote method 'download-and-open-task-folder':
+TypeError: invalid url
+```
+
+Every task triggered the same error so no folders were downloaded locally.
+
+## Root Cause
+`/api/jobs/[taskId]/files` returned a list that included directory entries. These objects had `url: ''` because folders themselves are not downloadable. `blackpaint/src/index.ts` attempted to `axios.get()` each provided URL. When an empty string was encountered Node's URL parser threw `TypeError: Invalid URL`, aborting the entire download.
+
+## Fix
+The `getFilesRecursively` helper in `app/api/jobs/[taskId]/files/route.ts` now skips adding directories to the result. Only files with valid URLs are returned. The Electron handler already creates directories from each file's `relativePath`, so downloads proceed without errors.
+

--- a/taintedpaint/app/api/jobs/[taskId]/files/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/files/route.ts
@@ -27,16 +27,6 @@ async function getFilesRecursively(directory: string, basePath: string, baseUrl:
     if (ignoredFiles.includes(entry.name)) continue;
     const fullPath = path.join(directory, entry.name);
     if (entry.isDirectory()) {
-      const relativePath = path.relative(basePath, fullPath);
-      const stats = await fs.stat(fullPath);
-
-      fileList.push({
-        filename: entry.name,
-        relativePath,
-        url: '',
-        mtimeMs: stats.mtimeMs,
-        isDir: true,
-      });
       const subFiles = await getFilesRecursively(fullPath, basePath, baseUrl);
       fileList = fileList.concat(subFiles);
     } else if (entry.isFile()) {


### PR DESCRIPTION
## Summary
- skip directory entries from the `/files` API
- document invalid URL error and its resolution

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688362412f6c832d94986aa578e2fed7