### PR TITLE
Implement holistic editing in Kanban drawer

### DIFF
--- a/taintedpaint/app/api/jobs/[taskId]/update/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/update/route.ts
@@ -8,7 +8,26 @@ export async function PATCH(
 ) {
   const { taskId } = await params;
   try {
-    const { deliveryDate, notes } = await req.json();
+    const {
+      customerName,
+      representative,
+      ynmxId,
+      inquiryDate,
+      deliveryDate,
+      notes,
+    } = await req.json();
+    if (customerName !== undefined && typeof customerName !== 'string') {
+      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+    }
+    if (representative !== undefined && typeof representative !== 'string') {
+      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+    }
+    if (ynmxId !== undefined && typeof ynmxId !== 'string' && ynmxId !== null) {
+      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+    }
+    if (inquiryDate !== undefined && typeof inquiryDate !== 'string') {
+      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+    }
     if (deliveryDate !== undefined && typeof deliveryDate !== 'string') {
       return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
     }
@@ -20,8 +39,16 @@ export async function PATCH(
     await updateBoardData(async data => {
       const t = data.tasks[taskId];
       if (!t) throw new Error('Task not found');
+      if (typeof customerName === 'string') t.customerName = customerName.trim();
+      if (typeof representative === 'string') t.representative = representative.trim();
+      if (typeof ynmxId === 'string') {
+        t.ynmxId = ynmxId.trim() || undefined;
+      } else if (ynmxId === null) {
+        t.ynmxId = undefined;
+      }
+      if (typeof inquiryDate === 'string') t.inquiryDate = inquiryDate;
       if (typeof deliveryDate === 'string') t.deliveryDate = deliveryDate;
-      if (typeof notes === 'string') t.notes = notes;
+      if (typeof notes === 'string') t.notes = notes.trim();
       updatedTask = t;
     });
 

--- a/taintedpaint/components/KanbanDrawer.tsx
+++ b/taintedpaint/components/KanbanDrawer.tsx
@@ -4,10 +4,19 @@
 import type { Task } from "@/types";
 import type { ElectronAPI } from "@/types/electron";
 import { useState, useCallback, useEffect, useRef } from "react";
-import { X, CalendarDays, MessageSquare, Folder, Pencil } from "lucide-react";
+import {
+  X,
+  CalendarDays,
+  MessageSquare,
+  Folder,
+  Pencil,
+  Check,
+  Building2,
+  User,
+  Hash,
+} from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { Button } from "@/components/ui/button";
 
 interface KanbanDrawerProps {
   isOpen: boolean;
@@ -15,12 +24,7 @@ interface KanbanDrawerProps {
   columnTitle: string | null;
   onClose: () => void;
   onTaskUpdated?: (task: Task) => void;
-  /**
-   * Display mode of the board. When `business`, show full
-   * customer details even if the task has been serialized.
-   * Defaults to `business`.
-   */
-  viewMode?: 'business' | 'production';
+  viewMode?: "business" | "production";
 }
 
 export default function KanbanDrawer({
@@ -29,33 +33,66 @@ export default function KanbanDrawer({
   columnTitle,
   onClose,
   onTaskUpdated,
-  viewMode = 'business',
+  viewMode = "business",
 }: KanbanDrawerProps) {
   const [isDownloading, setIsDownloading] = useState(false);
-  const [deliveryDate, setDeliveryDate] = useState("");
-  const [notes, setNotes] = useState("");
-  const [editNotesValue, setEditNotesValue] = useState("");
-  const [isEditingNotes, setIsEditingNotes] = useState(false);
-  const notesRef = useRef<HTMLTextAreaElement>(null);
-  const dateInputRef = useRef<HTMLInputElement>(null);
+  const [isEditMode, setIsEditMode] = useState(false);
 
-  const openDatePicker = () => {
-    const input = dateInputRef.current;
-    if (!input) return;
-    if ((input as any).showPicker) {
-      (input as any).showPicker();
-    } else {
-      input.focus();
-      input.click();
-    }
-  };
+  const [formData, setFormData] = useState({
+    customerName: "",
+    representative: "",
+    ynmxId: "",
+    inquiryDate: "",
+    deliveryDate: "",
+    notes: "",
+  });
+
+  const customerInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    setDeliveryDate(task?.deliveryDate || "");
-    setNotes(task?.notes || "");
-    setEditNotesValue(task?.notes || "");
-    setIsEditingNotes(false);
+    if (task) {
+      setFormData({
+        customerName: task.customerName || "",
+        representative: task.representative || "",
+        ynmxId: task.ynmxId || "",
+        inquiryDate: task.inquiryDate || "",
+        deliveryDate: task.deliveryDate || "",
+        notes: task.notes || "",
+      });
+    }
+    setIsEditMode(false);
   }, [task]);
+
+  useEffect(() => {
+    if (isEditMode && customerInputRef.current) {
+      customerInputRef.current.focus();
+    }
+  }, [isEditMode]);
+
+  const handleSave = useCallback(async () => {
+    if (!task) return;
+    try {
+      const res = await fetch(`/api/jobs/${task.id}/update`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          customerName: formData.customerName,
+          representative: formData.representative,
+          ynmxId: formData.ynmxId,
+          inquiryDate: formData.inquiryDate,
+          deliveryDate: formData.deliveryDate,
+          notes: formData.notes,
+        }),
+      });
+      if (res.ok) {
+        const updated: Task = await res.json();
+        onTaskUpdated?.(updated);
+        setIsEditMode(false);
+      }
+    } catch (err) {
+      console.error("Failed to update task", err);
+    }
+  }, [task, formData, onTaskUpdated]);
 
   const handleDownloadAndOpen = useCallback(async () => {
     if (!task) return;
@@ -73,8 +110,7 @@ export default function KanbanDrawer({
         alert("此任务没有可下载的文件。");
         return;
       }
-      const folderName =
-        task.ynmxId || `${task.customerName} - ${task.representative} - ${task.id}`;
+      const folderName = task.ynmxId || `${task.customerName} - ${task.representative} - ${task.id}`;
       await electronAPI.downloadAndOpenTaskFolder(task.id, folderName, filesToDownload);
     } catch (err: any) {
       console.error("Download and open failed:", err);
@@ -84,49 +120,6 @@ export default function KanbanDrawer({
     }
   }, [task]);
 
-  const saveDeliveryDate = useCallback(
-    async (date: string = deliveryDate) => {
-      if (!task) return;
-      try {
-        const res = await fetch(`/api/jobs/${task.id}/update`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ deliveryDate: date }),
-        });
-        if (res.ok) {
-          const updated: Task = await res.json();
-          setDeliveryDate(updated.deliveryDate || "");
-          onTaskUpdated?.(updated);
-        }
-      } catch (err) {
-        console.error('Failed to update delivery date', err);
-      }
-    },
-    [task, deliveryDate, onTaskUpdated],
-  );
-
-  const saveNotes = useCallback(
-    async (text: string = notes) => {
-      if (!task) return;
-      try {
-        const res = await fetch(`/api/jobs/${task.id}/update`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ notes: text }),
-        });
-        if (res.ok) {
-          const updated: Task = await res.json();
-          setNotes(updated.notes || "");
-          setEditNotesValue(updated.notes || "");
-          onTaskUpdated?.(updated);
-        }
-      } catch (err) {
-        console.error('Failed to update notes', err);
-      }
-    },
-    [task, notes, onTaskUpdated],
-  );
-
   if (!task) {
     return (
       <aside className="fixed inset-y-0 right-0 w-[400px] translate-x-full pointer-events-none transition-transform duration-400 ease-[cubic-bezier(0.32,0.72,0,1)]" />
@@ -134,170 +127,227 @@ export default function KanbanDrawer({
   }
 
   return (
-    <>
-      <aside
-        className={`fixed inset-y-0 right-0 w-[400px] bg-white/90 backdrop-blur-md border-l border-gray-200/80 transition-transform duration-400 ease-[cubic-bezier(0.32,0.72,0,1)] z-50 flex flex-col ${isOpen ? "translate-x-0 shadow-[0_8px_64px_0_rgba(0,0,0,0.25)]" : "translate-x-full"}`}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex-shrink-0 px-6 pt-6 pb-0 flex items-start justify-between">
-          <div className="flex-1 min-w-0 pr-4">
-            <h1 className="text-xl font-semibold text-black tracking-tight truncate -mb-0.5">
-              {viewMode === 'business'
-                ? task.customerName
-                : task.ynmxId || task.customerName}
-            </h1>
-            <div className="flex items-center gap-2 mt-1">
-              {viewMode === 'business' && (
-                <p className="text-[15px] text-black/60 truncate">{task.representative}</p>
-              )}
-              {viewMode === 'business' && task.ynmxId && (
-                <span className="text-[13px] font-medium text-black/50 bg-black/5 px-2 py-0.5 rounded-full">
-                  {task.ynmxId}
-                </span>
-              )}
-              {columnTitle && (
-                <>
-                  {(viewMode === 'business' || !task.ynmxId) && (
-                    <span className="text-black/30 text-sm">·</span>
-                  )}
-                  <span className="text-[13px] font-medium text-black/50 bg-black/5 px-2 py-0.5 rounded-full">
-                    {columnTitle}
-                  </span>
-                </>
-              )}
-            </div>
+    <aside
+      className={`fixed inset-y-0 right-0 w-[400px] bg-white/95 backdrop-blur-xl border-l border-gray-200/50 transition-all duration-500 ease-[cubic-bezier(0.32,0.72,0,1)] z-50 flex flex-col ${
+        isOpen ? "translate-x-0 shadow-[0_8px_64px_0_rgba(0,0,0,0.12)]" : "translate-x-full"
+      }`}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {/* Header */}
+      <div className="flex-shrink-0 px-6 pt-6 pb-4 border-b border-gray-200/50">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-[13px] font-semibold text-gray-500 uppercase tracking-wider">Task Details</h2>
+          <div className="flex items-center gap-2">
+            {isEditMode ? (
+              <button
+                onClick={handleSave}
+                className="h-8 px-3 flex items-center gap-2 rounded-lg bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium transition-all duration-200 hover:shadow-lg hover:shadow-blue-500/20"
+              >
+                <Check className="h-3.5 w-3.5" />
+                保存
+              </button>
+            ) : (
+              <button
+                onClick={() => setIsEditMode(true)}
+                className="h-8 px-3 flex items-center gap-2 rounded-lg bg-gray-100 hover:bg-gray-200 text-gray-700 text-sm font-medium transition-all duration-200"
+              >
+                <Pencil className="h-3.5 w-3.5" />
+                编辑
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              className="h-8 w-8 flex items-center justify-center rounded-lg hover:bg-gray-100 transition-all duration-200"
+            >
+              <X className="h-4 w-4 text-gray-500" />
+            </button>
           </div>
-          <button
-            onClick={onClose}
-            className="flex-shrink-0 h-8 w-8 flex items-center justify-center rounded-md bg-black/5 hover:bg-black/10 transition-colors duration-200"
-          >
-            <X className="h-4 w-4 text-black/60" />
-          </button>
         </div>
 
-        <div className="flex-1 overflow-y-auto px-6 pt-6 pb-6">
-          <div className="space-y-3 mb-8">
-            <div className="flex items-center justify-between py-3 border-b border-black/[0.08]">
-              <div className="flex items-center gap-3">
-                <CalendarDays className="h-4 w-4 text-black/40" />
-                <span className="text-[15px] text-black/60">询价日期</span>
-              </div>
-              <span className="text-[15px] font-medium text-black">{task.inquiryDate}</span>
-            </div>
-            <div className="flex items-center justify-between py-3 border-b border-black/[0.08]">
-              <div className="flex items-center gap-3">
-                <CalendarDays className="h-4 w-4 text-black/40" />
-                <span className="text-[15px] text-black/60">交期</span>
-              </div>
-              <div className="relative flex items-center gap-2">
-                {deliveryDate && (
-                  <span className="text-[15px] font-medium text-black">{deliveryDate}</span>
-                )}
-                <button
-                  onClick={openDatePicker}
-                  className="h-7 w-7 flex items-center justify-center rounded-md bg-black/5 hover:bg-black/10 transition-colors"
-                  aria-label="设置交期"
-                >
-                  <Pencil className="h-4 w-4 text-black/60" />
-                </button>
+        {/* Primary Info */}
+        <div className="space-y-3">
+          {isEditMode ? (
+            <>
+              <Input
+                ref={customerInputRef}
+                value={formData.customerName}
+                onChange={(e) => setFormData({ ...formData, customerName: e.target.value })}
+                placeholder="客户名称"
+                className="text-lg font-semibold border-0 bg-gray-50 focus:bg-white transition-all duration-200 rounded-lg"
+              />
+              <div className="grid grid-cols-2 gap-3">
                 <Input
-                  ref={dateInputRef}
-                  type="date"
-                  value={deliveryDate}
-                  onChange={(e) => {
-                    setDeliveryDate(e.target.value);
-                    saveDeliveryDate(e.target.value);
-                  }}
-                  className="sr-only"
-                  style={{ colorScheme: 'light' }}
+                  value={formData.representative}
+                  onChange={(e) => setFormData({ ...formData, representative: e.target.value })}
+                  placeholder="代表人"
+                  className="border-0 bg-gray-50 focus:bg-white transition-all duration-200 rounded-lg"
+                />
+                <Input
+                  value={formData.ynmxId}
+                  onChange={(e) => setFormData({ ...formData, ynmxId: e.target.value })}
+                  placeholder="生产编号"
+                  className="border-0 bg-gray-50 focus:bg-white transition-all duration-200 rounded-lg font-mono"
+                />
+              </div>
+            </>
+          ) : (
+            <>
+              <h1 className="text-xl font-semibold text-gray-900">
+                {viewMode === "business" ? formData.customerName : formData.ynmxId || formData.customerName}
+              </h1>
+              <div className="flex items-center gap-3 text-sm">
+                {viewMode === "business" && formData.representative && (
+                  <span className="text-gray-600">{formData.representative}</span>
+                )}
+                {formData.ynmxId && (
+                  <span className="px-2.5 py-1 bg-gray-100 text-gray-700 rounded-full font-mono text-xs">
+                    {formData.ynmxId}
+                  </span>
+                )}
+                {columnTitle && (
+                  <span className="px-2.5 py-1 bg-blue-50 text-blue-700 rounded-full text-xs font-medium">
+                    {columnTitle}
+                  </span>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto px-6 py-6">
+        <div className="space-y-4">
+          {/* Customer Info Section */}
+          {isEditMode && viewMode === "production" && (
+            <div className="p-4 bg-gray-50 rounded-xl space-y-3">
+              <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">客户信息</h3>
+              <div className="space-y-3">
+                <div className="relative">
+                  <Building2 className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                  <Input
+                    value={formData.customerName}
+                    onChange={(e) => setFormData({ ...formData, customerName: e.target.value })}
+                    placeholder="客户名称"
+                    className="pl-10 border-0 bg-white transition-all duration-200 rounded-lg"
+                  />
+                </div>
+                <div className="relative">
+                  <User className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                  <Input
+                    value={formData.representative}
+                    onChange={(e) => setFormData({ ...formData, representative: e.target.value })}
+                    placeholder="代表人"
+                    className="pl-10 border-0 bg-white transition-all duration-200 rounded-lg"
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Manufacturing ID */}
+          {isEditMode && viewMode === "business" && (
+            <div className="p-4 bg-gray-50 rounded-xl">
+              <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">生产信息</h3>
+              <div className="relative">
+                <Hash className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                <Input
+                  value={formData.ynmxId}
+                  onChange={(e) => setFormData({ ...formData, ynmxId: e.target.value })}
+                  placeholder="生产编号"
+                  className="pl-10 border-0 bg-white transition-all duration-200 rounded-lg font-mono"
                 />
               </div>
             </div>
-            <div className="py-3 border-b border-black/[0.08]">
-              <div className="flex items-center justify-between mb-2">
+          )}
+
+          {/* Dates Section */}
+          <div className="p-4 bg-gray-50 rounded-xl space-y-3">
+            <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">时间信息</h3>
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
                 <div className="flex items-center gap-3">
-                  <MessageSquare className="h-4 w-4 text-black/40" />
-                  <span className="text-[15px] text-black/60">备注</span>
+                  <CalendarDays className="h-4 w-4 text-gray-400" />
+                  <span className="text-sm text-gray-600">询价日期</span>
                 </div>
-                <button
-                  onClick={() => {
-                    setEditNotesValue(notes);
-                    setIsEditingNotes(true);
-                    setTimeout(() => notesRef.current?.focus(), 50);
-                  }}
-                  className="h-7 w-7 flex items-center justify-center rounded-md bg-black/5 hover:bg-black/10 transition-colors"
-                  aria-label="编辑备注"
-                >
-                  <Pencil className="h-4 w-4 text-black/60" />
-                </button>
-              </div>
-              {isEditingNotes ? (
-                <div>
-                  <Textarea
-                    ref={notesRef}
-                    value={editNotesValue}
-                    onChange={(e) => setEditNotesValue(e.target.value)}
-                    className="text-[15px] text-black bg-white/60 focus:bg-white transition-all duration-200"
+                {isEditMode ? (
+                  <Input
+                    type="date"
+                    value={formData.inquiryDate}
+                    onChange={(e) => setFormData({ ...formData, inquiryDate: e.target.value })}
+                    className="w-auto border-0 bg-white transition-all duration-200 rounded-lg"
                   />
-                  <div className="flex justify-end gap-2 mt-2">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => {
-                        setIsEditingNotes(false);
-                        setEditNotesValue(notes);
-                      }}
-                    >
-                      取消
-                    </Button>
-                    <Button
-                      size="sm"
-                      onClick={() => {
-                        setIsEditingNotes(false);
-                        saveNotes(editNotesValue);
-                      }}
-                    >
-                      确认
-                    </Button>
-                  </div>
+                ) : (
+                  <span className="text-sm font-medium text-gray-900">{formData.inquiryDate || "未设置"}</span>
+                )}
+              </div>
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <CalendarDays className="h-4 w-4 text-gray-400" />
+                  <span className="text-sm text-gray-600">交货日期</span>
                 </div>
-              ) : (
-                <p className="text-[15px] text-black leading-relaxed ml-7 whitespace-pre-wrap">
-                  {notes}
-                </p>
-              )}
+                {isEditMode ? (
+                  <Input
+                    type="date"
+                    value={formData.deliveryDate}
+                    onChange={(e) => setFormData({ ...formData, deliveryDate: e.target.value })}
+                    className="w-auto border-0 bg-white transition-all duration-200 rounded-lg"
+                  />
+                ) : (
+                  <span className="text-sm font-medium text-gray-900">{formData.deliveryDate || "未设置"}</span>
+                )}
+              </div>
             </div>
           </div>
 
-          <div className="space-y-3">
-            <button
-              onClick={handleDownloadAndOpen}
-              disabled={isDownloading}
-              className="w-full flex items-center gap-4 p-4 bg-blue-500/8 hover:bg-blue-500/12 rounded-lg transition-all duration-200 group disabled:opacity-60 disabled:cursor-wait"
-            >
-              <div className="flex items-center justify-center h-10 w-10 rounded bg-blue-500/15 group-hover:bg-blue-500/20 transition-colors duration-200">
-                {isDownloading ? (
-                  <svg className="h-5 w-5 text-blue-600 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <circle cx="12" cy="12" r="10" opacity="0.25" />
-                    <path d="M22 12a10 10 0 0 1-10 10" />
-                  </svg>
-                ) : (
-                  <Folder className="h-5 w-5 text-blue-600" />
-                )}
-              </div>
-              <div className="flex-1 text-left">
-                <p className="text-[15px] font-medium text-black">
-                  {isDownloading ? "正在下载..." : "打开文件夹"}
-                </p>
-                <p className="text-[13px] text-black/50">
-                  {isDownloading ? "文件将保存在您的下载目录" : "快速获取所有项目文件"}
-                </p>
-              </div>
-            </button>
-
+          {/* Notes Section */}
+          <div className="p-4 bg-gray-50 rounded-xl">
+            <div className="flex items-center gap-3 mb-3">
+              <MessageSquare className="h-4 w-4 text-gray-400" />
+              <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider">备注</h3>
+            </div>
+            {isEditMode ? (
+              <Textarea
+                value={formData.notes}
+                onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
+                placeholder="添加备注..."
+                rows={4}
+                className="border-0 bg-white transition-all duration-200 rounded-lg resize-none"
+              />
+            ) : (
+              <p className="text-sm text-gray-700 whitespace-pre-wrap leading-relaxed">
+                {formData.notes || "暂无备注"}
+              </p>
+            )}
           </div>
+
+          {/* Action Button */}
+          <button
+            onClick={handleDownloadAndOpen}
+            disabled={isDownloading}
+            className="w-full flex items-center gap-4 p-4 bg-blue-50 hover:bg-blue-100 rounded-xl transition-all duration-200 group disabled:opacity-60 disabled:cursor-wait"
+          >
+            <div className="flex items-center justify-center h-10 w-10 rounded-lg bg-blue-100 group-hover:bg-blue-200 transition-colors duration-200">
+              {isDownloading ? (
+                <svg className="h-5 w-5 text-blue-600 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx="12" cy="12" r="10" opacity="0.25" />
+                  <path d="M22 12a10 10 0 0 1-10 10" />
+                </svg>
+              ) : (
+                <Folder className="h-5 w-5 text-blue-600" />
+              )}
+            </div>
+            <div className="flex-1 text-left">
+              <p className="text-sm font-medium text-gray-900">
+                {isDownloading ? "正在下载..." : "打开文件夹"}
+              </p>
+              <p className="text-xs text-gray-500">
+                {isDownloading ? "文件将保存在您的下载目录" : "快速获取所有项目文件"}
+              </p>
+            </div>
+          </button>
         </div>
-      </aside>
-    </>
+      </div>
+    </aside>
   );
 }


### PR DESCRIPTION
## Summary
- allow editing of all task fields via Kanban drawer
- expose additional fields on job update API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688368a45f98832d86494cb5cab4602e