### PR TITLE
Fix sync deletion on missing server directory

### DIFF
--- a/blackpaint/src/sync.ts
+++ b/blackpaint/src/sync.ts
@@ -190,11 +190,13 @@ async function pullFromServer(
       files.map(f => path.join(localRoot, sanitizeRelPath(f.relativePath)))
     );
     const localFiles = await listLocalFiles(localRoot);
-    for (const lp of localFiles) {
-      if (!remoteSet.has(lp) && !pendingUploads.has(lp)) {
-        pendingWrites.add(lp);
-        await fs.unlink(lp).catch(() => {});
-        pendingWrites.delete(lp);
+    if (remoteSet.size > 0) {
+      for (const lp of localFiles) {
+        if (!remoteSet.has(lp) && !pendingUploads.has(lp)) {
+          pendingWrites.add(lp);
+          await fs.unlink(lp).catch(() => {});
+          pendingWrites.delete(lp);
+        }
       }
     }
 

--- a/issues-local-delete-on-missing-server-folder.md
+++ b/issues-local-delete-on-missing-server-folder.md
@@ -1,0 +1,15 @@
+# Local Files Deleted When Server Folder Missing
+
+## Architecture Recap
+- **taintedpaint** hosts uploaded files under `public/storage/tasks/<taskId>`.
+- **blackpaint** downloads a task's folder and keeps it in sync via `startBidirectionalSync` in `blackpaint/src/sync.ts`.
+
+## What Happened
+If the server's task directory was removed (for example after a server cleanup) while the metadata file still listed the task, subsequent sync cycles returned an empty file list. The client interpreted this as the task having no files and deleted every local file under that task.
+
+## Root Cause
+`/api/jobs/[taskId]/files` previously responded with an empty array when the directory did not exist. `pullFromServer` treated an empty list as truth and removed any local paths not found in the response.
+
+## Fix
+- The API route now returns `404` with `{"error":"Task files missing"}` when the directory is absent.
+- `pullFromServer` only removes local files if the remote list contains at least one entry. When the response is empty (or a 404 is received) the existing local files are preserved.

--- a/taintedpaint/app/api/jobs/[taskId]/files/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/files/route.ts
@@ -82,7 +82,7 @@ export async function GET(
     return NextResponse.json(files);
   } catch (err: any) {
     if (err.code === 'ENOENT') {
-      return NextResponse.json([]);
+      return NextResponse.json({ error: 'Task files missing' }, { status: 404 });
     }
     console.error(`Failed to list files for task ${taskId}:`, err);
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });


### PR DESCRIPTION
## Summary
- add doc for missing server storage deletion issue
- avoid deleting local files when server returns no list
- return 404 in files API when task directory missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68842bb1d6a0832da1f880415b8e2162