### PR TITLE
Enable KanbanDrawer for archived items

### DIFF
--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -229,8 +229,6 @@ export default function KanbanBoard() {
   const handleTaskClick = (task: Task, e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    if (task.columnId === "archive" || task.columnId === "archive2") return
-
     const column = columns.find((c) => c.id === task.columnId)
     setSelectedTaskColumnTitle(column ? column.title : null)
     setSelectedTask(task)


### PR DESCRIPTION
## Summary
- remove early return that blocked opening archived tasks in `kanban-board.tsx`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68843df7d334832db20970928f8b9cd7