### PR TITLE
Fix folder upload failing due to cross-device rename

### DIFF
--- a/taintedpaint/app/api/jobs/route.ts
+++ b/taintedpaint/app/api/jobs/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { promises as fs, createWriteStream } from "fs";
 import { Readable } from "stream";
 import Busboy from "busboy";
+import { renameWithFallback } from "@/lib/fileUtils";
 import os from "os";
 import path from "path";
 import type { BoardData, Task } from "@/types";
@@ -106,7 +107,7 @@ export async function POST(req: NextRequest) {
       if (safeRelativePath.includes('..')) continue;
       const destinationPath = path.join(taskDirectoryPath, safeRelativePath);
       await fs.mkdir(path.dirname(destinationPath), { recursive: true });
-      await fs.rename(tempFiles[i], destinationPath);
+      await renameWithFallback(tempFiles[i], destinationPath);
     }
 
     const newTask: Task = {

--- a/taintedpaint/lib/fileUtils.ts
+++ b/taintedpaint/lib/fileUtils.ts
@@ -26,3 +26,16 @@ export async function writeJsonAtomic(filePath: string, data: any) {
     throw err
   }
 }
+
+export async function renameWithFallback(oldPath: string, newPath: string) {
+  try {
+    await fs.rename(oldPath, newPath)
+  } catch (err: any) {
+    if (err?.code === 'EXDEV') {
+      await fs.copyFile(oldPath, newPath)
+      await fs.unlink(oldPath)
+    } else {
+      throw err
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `renameWithFallback` helper to handle cross-device moves
- use it in `/api/jobs` when saving uploaded files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688485321344832da70d268a2deae352