### PR TITLE
Fix params destructuring in API routes

### DIFF
--- a/taintedpaint/app/api/jobs/[taskId]/delete-file/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/delete-file/route.ts
@@ -15,7 +15,7 @@ export async function POST(
   req: NextRequest,
   { params }: { params: { taskId: string } }
 ) {
-  const { taskId } = await params;
+  const { taskId } = params;
   if (!taskId) {
     return NextResponse.json({ error: "Task ID is required" }, { status: 400 });
   }

--- a/taintedpaint/app/api/jobs/[taskId]/files/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/files/route.ts
@@ -59,7 +59,7 @@ export async function GET(
   req: NextRequest,
   { params }: { params: { taskId: string } }
 ) {
-  const { taskId } = await params;
+  const { taskId } = params;
   if (!taskId) {
     return NextResponse.json({ error: "Task ID is required" }, { status: 400 });
   }

--- a/taintedpaint/app/api/jobs/[taskId]/update-file/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/update-file/route.ts
@@ -15,7 +15,7 @@ export async function POST(
   req: NextRequest,
   { params }: { params: { taskId: string } }
 ) {
-  const { taskId } = await params;
+  const { taskId } = params;
   if (!taskId) {
     return NextResponse.json({ error: "Task ID is required" }, { status: 400 });
   }

--- a/taintedpaint/app/api/jobs/[taskId]/update/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/update/route.ts
@@ -6,7 +6,7 @@ export async function PATCH(
   req: NextRequest,
   { params }: { params: { taskId: string } }
 ) {
-  const { taskId } = await params;
+  const { taskId } = params;
   try {
     const {
       customerName,

--- a/taintedpaint/app/api/jobs/[taskId]/upload/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/upload/route.ts
@@ -16,7 +16,7 @@ export async function POST(
   req: NextRequest,
   { params }: { params: { taskId: string } }
 ) {
-  const { taskId } = await params;
+  const { taskId } = params;
   if (!taskId) {
     return NextResponse.json({ error: "Task ID is required" }, { status: 400 });
   }


### PR DESCRIPTION
## Summary
- avoid awaiting params in `[taskId]` API routes

## Testing
- `npm test`
- `npm run build` *(fails: Failed to fetch `Geist` fonts)*

------
https://chatgpt.com/codex/tasks/task_e_688489d8e100832d8ee4df4f7830cae6