### PR TITLE
Move storage out of public directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/taintedpaint/public/storage/
+/storage

--- a/ISSUES.MD
+++ b/ISSUES.MD
@@ -1,7 +1,7 @@
 # File Sync Error When Downloading Job Folder
 
 ## Architecture Overview
-- **taintedpaint** provides the Next.js web interface and REST API. Job files are saved under `public/storage/tasks`. Metadata is tracked in `public/storage/metadata.json`.
+- **taintedpaint** provides the Next.js web interface and REST API. Job files are saved under `storage/tasks`. Metadata is tracked in `storage/metadata.json`.
 - **blackpaint** is the Electron wrapper (Estara). When the Kanban drawer's "Open" button is used, the Electron main process downloads the job's files to the user's `Downloads` directory and starts a bidirectional sync (`startBidirectionalSync` in `blackpaint/src/sync.ts`).
 
 ## Problem Description

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The project is split into two directories:
 ### Data flow
 
 1. **Metadata store** – All tasks and column data are persisted to
-   `taintedpaint/public/storage/metadata.json` on the server.
+   `storage/metadata.json` at the repository root.
 2. **Board loading** – The `KanbanBoard` component fetches this file through
    `/api/jobs` and keeps the board state in React.
 3. **Creating jobs** – `CreateJobForm` uploads a folder of files and creates a

--- a/file-sync.md
+++ b/file-sync.md
@@ -6,7 +6,7 @@ This document explains how Estara's Electron clients communicate with the Next.j
 
 The project consists of two parts:
 
-- **taintedpaint** – the server and web UI built with Next.js. It exposes API routes under `/api/jobs` for managing task files and metadata. Uploaded files live in `public/storage/tasks/{taskId}` and metadata is stored in `public/storage/metadata.json`.
+- **taintedpaint** – the server and web UI built with Next.js. It exposes API routes under `/api/jobs` for managing task files and metadata. Uploaded files live in `storage/tasks/{taskId}` and metadata is stored in `storage/metadata.json`.
 - **blackpaint (Estara)** – the Electron desktop client. When a user opens a task, it downloads that task's files and starts a two‑way sync process.
 
 ## Opening a Task

--- a/issues-ebusy-reopening.md
+++ b/issues-ebusy-reopening.md
@@ -1,7 +1,7 @@
 # EBUSY Error When Reopening Downloaded Job
 
 ## Architecture Overview
-- **taintedpaint** is the Next.js server and web UI. Task files live under `public/storage/tasks/{taskId}`.
+- **taintedpaint** is the Next.js server and web UI. Task files live under `storage/tasks/{taskId}`.
 - **blackpaint (Estara)** downloads a task's files to `C:\EstaraSync/<Folder>` on Windows (or `~/Desktop/Estara 数据/<Folder>` on other platforms) and starts `startBidirectionalSync` from `blackpaint/src/sync.ts`.
 
 ## What Happened

--- a/issues-invalid-url-download.md
+++ b/issues-invalid-url-download.md
@@ -1,7 +1,7 @@
 # Download Fails with Invalid URL Error
 
 ## Architecture Overview
-- **taintedpaint** hosts the Next.js API routes and serves uploaded files from `public/storage/tasks/{taskId}`.
+- **taintedpaint** hosts the Next.js API routes and serves uploaded files from `storage/tasks/{taskId}`.
 - **blackpaint** is the Electron client (Estara). The Kanban drawer calls `downloadAndOpenTaskFolder` which retrieves `/api/jobs/{taskId}/files`, downloads each entry and starts sync.
 
 ## Problem

--- a/issues-local-delete-on-missing-server-folder.md
+++ b/issues-local-delete-on-missing-server-folder.md
@@ -1,7 +1,7 @@
 # Local Files Deleted When Server Folder Missing
 
 ## Architecture Recap
-- **taintedpaint** hosts uploaded files under `public/storage/tasks/<taskId>`.
+- **taintedpaint** hosts uploaded files under `storage/tasks/<taskId>`.
 - **blackpaint** downloads a task's folder and keeps it in sync via `startBidirectionalSync` in `blackpaint/src/sync.ts`.
 
 ## What Happened

--- a/issues-missing-files-after-upload.md
+++ b/issues-missing-files-after-upload.md
@@ -1,7 +1,7 @@
 # Files Disappear After Syncing on Another Client
 
 ## Architecture Recap
-- **taintedpaint** stores uploaded job files under `public/storage/tasks/{taskId}`.
+- **taintedpaint** stores uploaded job files under `storage/tasks/{taskId}`.
 - **blackpaint** downloads a job's files locally and runs `startBidirectionalSync` from `blackpaint/src/sync.ts`.
 
 ## What Happened

--- a/issues-nested-folders-sync.md
+++ b/issues-nested-folders-sync.md
@@ -1,14 +1,14 @@
 # Nested Folders Reappear in Downloads
 
 ## Architecture and Workflow Overview
-- **taintedpaint** serves as the Next.js web interface and provides REST API routes for file management. Uploaded jobs are stored under `public/storage/tasks/{taskId}`.
+- **taintedpaint** serves as the Next.js web interface and provides REST API routes for file management. Uploaded jobs are stored under `storage/tasks/{taskId}`.
 - **blackpaint (Estara)** is the Electron shell. When the user clicks *Open* in the Kanban drawer it downloads all job files to `~/Downloads/{folderName}` and starts a bidirectional sync via `startBidirectionalSync`.
 
 ## Problem
 When uploading a folder through the web interface each file is sent with its `webkitRelativePath`. This path includes the root folder name. The server stored the files exactly as received (e.g. `task-123/partA.pdf`). When Estara later downloaded the job it also created a folder named after the job (e.g. `YNMX-001`). Because the stored paths already contained the top level directory, the downloaded folder ended up containing another copy of the root (e.g. `YNMX-001/task-123/partA.pdf`). If the user deleted the extra subfolder locally it was recreated on the next sync because the server kept that prefix.
 
 ## Fix
-Strip the uploaded root folder name from each file path on the server. The `POST /api/jobs` route now removes the `folderName` prefix from every `filePaths` entry before saving. Newly created tasks therefore store files directly under `public/storage/tasks/{taskId}` without the extra subdirectory.
+Strip the uploaded root folder name from each file path on the server. The `POST /api/jobs` route now removes the `folderName` prefix from every `filePaths` entry before saving. Newly created tasks therefore store files directly under `storage/tasks/{taskId}` without the extra subdirectory.
 
 ## Result
 Opening a job in Estara now downloads files directly into the job folder without nesting. Deleting local folders no longer results in them reappearing from the server.

--- a/issues-pending-upload-cross-sync.md
+++ b/issues-pending-upload-cross-sync.md
@@ -1,7 +1,7 @@
 # Folder from Another Job Appears Inside a Task
 
 ## Architecture Recap
-- **taintedpaint** (Next.js web UI & API) stores uploaded job files under `public/storage/tasks/{taskId}`. Metadata about tasks lives in `public/storage/metadata.json`.
+- **taintedpaint** (Next.js web UI & API) stores uploaded job files under `storage/tasks/{taskId}`. Metadata about tasks lives in `storage/metadata.json`.
 - **blackpaint** (Electron client "Estara") downloads a job's files to the user's `Downloads/{folderName}` and runs `startBidirectionalSync` from `blackpaint/src/sync.ts` to keep local and remote files in sync.
 
 ## Problem

--- a/issues-task-drag-revert.md
+++ b/issues-task-drag-revert.md
@@ -1,7 +1,7 @@
 # Task Moves Revert to Previous Column
 
 ## Architecture Overview
-- **taintedpaint** – Next.js app providing the Kanban board and REST API. Board state is stored in `public/storage/metadata.json` and polled by the UI every 10 seconds.
+- **taintedpaint** – Next.js app providing the Kanban board and REST API. Board state is stored in `storage/metadata.json` and polled by the UI every 10 seconds.
 - **blackpaint** – not involved in this bug but synchronises files when tasks are opened.
 
 ## Problem

--- a/issues-temp-files-and-empty-dirs.md
+++ b/issues-temp-files-and-empty-dirs.md
@@ -1,7 +1,7 @@
 # LCK/BAK Files and Missing Empty Directories
 
 ## Architecture
-- **taintedpaint** runs the Next.js API. Task files live under `public/storage/tasks/<taskId>` and are listed through `/api/jobs/[taskId]/files`.
+- **taintedpaint** runs the Next.js API. Task files live under `storage/tasks/<taskId>` and are listed through `/api/jobs/[taskId]/files`.
 - **blackpaint (Estara)** downloads a job's folder then keeps it in sync via `startBidirectionalSync` in `blackpaint/src/sync.ts`.
 
 ## Problem

--- a/relevant-issue-name.md
+++ b/relevant-issue-name.md
@@ -1,11 +1,11 @@
 # Storage Folder Reappears After Deletion
 
 ## Architecture Overview
-- **taintedpaint** hosts the Next.js web app and REST API. Uploaded tasks are saved under `public/storage/tasks/<taskId>` and metadata lives in `public/storage/metadata.json`.
+- **taintedpaint** hosts the Next.js web app and REST API. Uploaded tasks are saved under `storage/tasks/<taskId>` and metadata lives in `storage/metadata.json`.
 - **blackpaint** is the Electron client (*Estara*). When a task is opened it downloads files locally and starts a bidirectional sync via `startBidirectionalSync` in `blackpaint/src/sync.ts`.
 
 ## Why deleted server files return
-When the server's `/public/storage` directory is removed, any running Estara clients still think their tasks exist. The sync process lists files locally and uploads missing ones to the server every 10 seconds. The upload route (`app/api/jobs/[taskId]/upload/route.ts`) previously wrote files to disk before checking that the task was still present in `metadata.json`. As a result, clients recreated `/storage/tasks/<taskId>` even though the metadata file was gone.
+When the server's `/storage` directory is removed, any running Estara clients still think their tasks exist. The sync process lists files locally and uploads missing ones to the server every 10 seconds. The upload route (`app/api/jobs/[taskId]/upload/route.ts`) previously wrote files to disk before checking that the task was still present in `metadata.json`. As a result, clients recreated `/storage/tasks/<taskId>` even though the metadata file was gone.
 
 ## Temporary metadata files
 `lib/boardDataStore.ts` writes updates using a lock file and a temporary path like `metadata.json.<uuid>.tmp` before renaming it to `metadata.json`.

--- a/taintedpaint/app/api/jobs/[taskId]/create-dir/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/create-dir/route.ts
@@ -3,7 +3,8 @@ import { promises as fs } from 'fs'
 import path from 'path'
 import { sanitizeRelativePath } from '@/lib/pathUtils.mjs'
 
-const TASKS_STORAGE_DIR = path.join(process.cwd(), 'public', 'storage', 'tasks')
+// Use storage directory at the repository root
+const TASKS_STORAGE_DIR = path.join(process.cwd(), '..', 'storage', 'tasks')
 
 export async function POST(
   req: NextRequest,

--- a/taintedpaint/app/api/jobs/[taskId]/delete-dir/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/delete-dir/route.ts
@@ -3,7 +3,8 @@ import { promises as fs } from 'fs'
 import path from 'path'
 import { sanitizeRelativePath } from '@/lib/pathUtils.mjs'
 
-const TASKS_STORAGE_DIR = path.join(process.cwd(), 'public', 'storage', 'tasks')
+// Use storage directory at the repository root
+const TASKS_STORAGE_DIR = path.join(process.cwd(), '..', 'storage', 'tasks')
 
 export async function POST(
   req: NextRequest,

--- a/taintedpaint/app/api/jobs/[taskId]/delete-file/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/delete-file/route.ts
@@ -6,7 +6,8 @@ import { updateBoardData } from "@/lib/boardDataStore";
 import { sanitizeRelativePath } from "@/lib/pathUtils.mjs";
 
 // --- Path Definitions ---
-const STORAGE_DIR = path.join(process.cwd(), "public", "storage");
+// Root-level storage directory keeps dynamic data outside of Next.js public
+const STORAGE_DIR = path.join(process.cwd(), "..", "storage");
 const TASKS_STORAGE_DIR = path.join(STORAGE_DIR, "tasks");
 const META_FILE = path.join(STORAGE_DIR, "metadata.json");
 // ------------------------

--- a/taintedpaint/app/api/jobs/[taskId]/files/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/files/route.ts
@@ -4,7 +4,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { promises as fs } from "fs";
 import path from "path";
 
-const TASKS_STORAGE_DIR = path.join(process.cwd(), "public", "storage", "tasks");
+// Serve files from the root-level storage directory
+const TASKS_STORAGE_DIR = path.join(process.cwd(), "..", "storage", "tasks");
 
 // A list of common system and temporary files to ignore
 const ignoredFiles = ['.DS_Store', 'Thumbs.db'];

--- a/taintedpaint/app/api/jobs/[taskId]/update-file/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/update-file/route.ts
@@ -7,7 +7,8 @@ import type { BoardData } from "@/types";
 import { updateBoardData } from "@/lib/boardDataStore";
 import { sanitizeRelativePath } from "@/lib/pathUtils.mjs";
 
-const STORAGE_DIR = path.join(process.cwd(), "public", "storage");
+// Root-level storage directory keeps dynamic data accessible in production
+const STORAGE_DIR = path.join(process.cwd(), "..", "storage");
 const TASKS_STORAGE_DIR = path.join(STORAGE_DIR, "tasks");
 const META_FILE = path.join(STORAGE_DIR, "metadata.json");
 

--- a/taintedpaint/app/api/jobs/[taskId]/upload/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/upload/route.ts
@@ -7,7 +7,8 @@ import type { BoardData } from "@/types";
 import { updateBoardData, readBoardData } from "@/lib/boardDataStore";
 
 // --- Path Definitions ---
-const STORAGE_DIR = path.join(process.cwd(), "public", "storage");
+// Root-level storage directory keeps dynamic data accessible in production
+const STORAGE_DIR = path.join(process.cwd(), "..", "storage");
 const TASKS_STORAGE_DIR = path.join(STORAGE_DIR, "tasks");
 const META_FILE = path.join(STORAGE_DIR, "metadata.json");
 // ------------------------

--- a/taintedpaint/app/api/jobs/route.ts
+++ b/taintedpaint/app/api/jobs/route.ts
@@ -12,7 +12,8 @@ import { baseColumns, START_COLUMN_ID } from "@/lib/baseColumns";
 import { readBoardData, updateBoardData } from "@/lib/boardDataStore";
 
 // --- Path Definitions ---
-const STORAGE_DIR = path.join(process.cwd(), "public", "storage");
+// Store uploads under a top-level storage directory rather than /public
+const STORAGE_DIR = path.join(process.cwd(), "..", "storage");
 const TASKS_STORAGE_DIR = path.join(STORAGE_DIR, "tasks");
 const META_FILE = path.join(STORAGE_DIR, "metadata.json");
 // ------------------------

--- a/taintedpaint/app/api/search/route.ts
+++ b/taintedpaint/app/api/search/route.ts
@@ -4,7 +4,8 @@ import { promises as fs } from "fs";
 import path from "path";
 import type { BoardData, Task } from "@/types";
 
-const META_FILE = path.join(process.cwd(), "public", "storage", "metadata.json");
+// Read metadata from the new root-level storage directory
+const META_FILE = path.join(process.cwd(), "..", "storage", "metadata.json");
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);

--- a/taintedpaint/app/storage/[...path]/route.ts
+++ b/taintedpaint/app/storage/[...path]/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { promises as fs } from 'fs'
+import path from 'path'
+
+// Serve files from the root-level storage directory
+const STORAGE_DIR = path.join(process.cwd(), '..', 'storage')
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { path: string[] } }
+) {
+  const parts = params.path || []
+  const filePath = path.join(STORAGE_DIR, ...parts)
+  const normalised = path.normalize(filePath)
+  if (!normalised.startsWith(STORAGE_DIR)) {
+    return new NextResponse('Invalid path', { status: 400 })
+  }
+  try {
+    const data = await fs.readFile(normalised)
+    return new NextResponse(data)
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      return new NextResponse('Not Found', { status: 404 })
+    }
+    console.error('file serve error', err)
+    return new NextResponse('Server Error', { status: 500 })
+  }
+}

--- a/taintedpaint/lib/boardDataStore.ts
+++ b/taintedpaint/lib/boardDataStore.ts
@@ -4,7 +4,9 @@ import { randomUUID } from 'crypto'
 import { baseColumns } from './baseColumns'
 import type { BoardData } from '@/types'
 
-const STORAGE_DIR = path.join(process.cwd(), 'public', 'storage')
+// Store dynamic data outside of the public directory so it remains
+// accessible when running `npm run build && npm run start`.
+const STORAGE_DIR = path.join(process.cwd(), '..', 'storage')
 const META_FILE = path.join(STORAGE_DIR, 'metadata.json')
 const LOCK_FILE = META_FILE + '.lock'
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -1,0 +1,51 @@
+# Migrating CrystalPaint Storage
+
+This guide explains how to move existing task files and metadata from
+`taintedpaint/public/storage` to the new `storage` directory in the repository
+root. The change is necessary because the old location was only served as static
+assets and files disappeared when running `npm run build && npm run start`.
+
+## 1. Stop the server
+If the development server is running, stop it now.
+
+## 2. Create the new directory
+In the project root run:
+
+```bash
+mkdir storage
+```
+
+## 3. Copy existing data
+Move everything from `taintedpaint/public/storage` into the new directory:
+
+```bash
+mv taintedpaint/public/storage/* storage/
+```
+
+(You can also copy the files if you prefer to keep a backup.)
+
+## 4. Clean up
+Remove the now-empty `taintedpaint/public/storage` folder:
+
+```bash
+rmdir taintedpaint/public/storage
+```
+
+## 5. Install dependencies
+From within `taintedpaint` install packages and build the project:
+
+```bash
+cd taintedpaint
+npm install
+npm run build
+```
+
+## 6. Start the server
+Run the production server from the `taintedpaint` directory:
+
+```bash
+npm start
+```
+
+The application will now read and write dynamic data under `../storage` which
+remains available in production.


### PR DESCRIPTION
## Summary
- store files under `storage` at the repo root
- serve `/storage/*` files through a new route
- update API routes and board data store paths
- ignore the new `storage` folder in git
- update docs to mention the new location
- add a migration tutorial

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688495359a70832dbf7c82bcba777048