### PR TITLE
Fix Next.js storage route typing

### DIFF
--- a/taintedpaint/app/storage/[...path]/route.ts
+++ b/taintedpaint/app/storage/[...path]/route.ts
@@ -7,9 +7,9 @@ const STORAGE_DIR = path.join(process.cwd(), '..', 'storage')
 
 export async function GET(
   _req: NextRequest,
-  { params }: { params: { path: string[] } }
+  { params }: { params: Promise<{ path: string[] }> }
 ) {
-  const parts = params.path || []
+  const { path: parts = [] } = await params
   const filePath = path.join(STORAGE_DIR, ...parts)
   const normalised = path.normalize(filePath)
   if (!normalised.startsWith(STORAGE_DIR)) {


### PR DESCRIPTION
## Summary
- fix the GET handler in `app/storage/[...path]` to match Next.js expected parameter types

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6884995057f4832db2ed349f255935b6