### PR TITLE
Fix missing storage directory handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-/storage
+/storage/*
+!/storage/.gitkeep

--- a/issues-missing-storage-dir.md
+++ b/issues-missing-storage-dir.md
@@ -1,0 +1,15 @@
+# Missing Storage Directory Prevents Job Creation
+
+## Architecture Overview
+- **taintedpaint** – Next.js server providing the Kanban board and API routes. Board data is persisted to `storage/metadata.json` at the repository root.
+- **blackpaint** – Electron wrapper (Estara) that simply loads the web app. It relies on the server to store uploaded folders and task updates.
+
+## Problem
+Running `npm run build && npm run start` produced a working web UI, but creating a job stalled indefinitely and dragging a task between columns reverted after refreshing the page.
+
+## Root Cause
+`lib/boardDataStore.ts` writes updates to `../storage/metadata.json`. When the `storage` directory does not exist, the first call to `fs.open(LOCK_FILE, 'wx')` throws `ENOENT`. The API routes catch this error and return 500 responses, so the frontend keeps waiting and never saves changes. Because no metadata file is written, subsequent page loads restore the previous board state.
+
+## Solution
+Ensure the storage directory is present before reading or writing board data. `boardDataStore.ts` now calls `fs.mkdir(STORAGE_DIR, { recursive: true })` inside an `ensureStorageDir` helper used by both `readBoardData` and `updateBoardData`. A `.gitkeep` file is also committed so `storage/` exists when cloning the repo.
+

--- a/taintedpaint/lib/boardDataStore.ts
+++ b/taintedpaint/lib/boardDataStore.ts
@@ -10,11 +10,16 @@ const STORAGE_DIR = path.join(process.cwd(), '..', 'storage')
 const META_FILE = path.join(STORAGE_DIR, 'metadata.json')
 const LOCK_FILE = META_FILE + '.lock'
 
+async function ensureStorageDir() {
+  await fs.mkdir(STORAGE_DIR, { recursive: true })
+}
+
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 export async function readBoardData(): Promise<BoardData> {
+  await ensureStorageDir()
   try {
     const raw = await fs.readFile(META_FILE, 'utf-8')
     const data = JSON.parse(raw)
@@ -28,6 +33,7 @@ export async function readBoardData(): Promise<BoardData> {
 export async function updateBoardData(
   updater: (data: BoardData) => void | Promise<void>
 ): Promise<BoardData> {
+  await ensureStorageDir()
   // simple lock using a temp file
   while (true) {
     try {


### PR DESCRIPTION
## Summary
- ensure storage directory exists before reading/writing metadata
- keep `storage/` folder in repo with `.gitkeep`
- document root cause of stalled uploads/dragging in `issues-missing-storage-dir.md`

## Testing
- `npm test`
- `npm run build`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_6884a05ae348832d90d5c3c4c74a2c48