### PR TITLE
Add task delete option

### DIFF
--- a/taintedpaint/app/api/jobs/[taskId]/delete/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/delete/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { updateBoardData } from '@/lib/boardDataStore';
+
+const STORAGE_DIR = path.join(process.cwd(), '..', 'storage');
+const TASKS_STORAGE_DIR = path.join(STORAGE_DIR, 'tasks');
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ taskId: string }> }
+) {
+  const { taskId } = await params;
+  if (!taskId) {
+    return NextResponse.json({ error: 'Task ID is required' }, { status: 400 });
+  }
+
+  try {
+    const taskDir = path.join(TASKS_STORAGE_DIR, taskId);
+    await fs.rm(taskDir, { recursive: true, force: true });
+
+    await updateBoardData(async data => {
+      delete data.tasks[taskId];
+      for (const col of data.columns) {
+        const idx = col.taskIds.indexOf(taskId);
+        if (idx !== -1) col.taskIds.splice(idx, 1);
+      }
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error(`Failed to delete task ${taskId}:`, err);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -186,6 +186,26 @@ export default function KanbanBoard() {
     setSelectedTask(updatedTask)
   }, [])
 
+  const handleTaskDeleted = useCallback(
+    async (taskId: string) => {
+      setTasks(prev => {
+        const t = { ...prev }
+        delete t[taskId]
+        return t
+      })
+      setColumns(prev =>
+        prev.map(col => ({
+          ...col,
+          taskIds: col.taskIds.filter(id => id !== taskId),
+        }))
+      )
+      setSelectedTask(null)
+      setIsDrawerOpen(false)
+      await fetchBoard(true)
+    },
+    [fetchBoard]
+  )
+
   const handleDragStart = (task: Task) => {
     setDraggedTask(task)
   }
@@ -517,6 +537,7 @@ export default function KanbanBoard() {
           viewMode={viewMode}
           onClose={closeDrawer}
           onTaskUpdated={handleTaskUpdated}
+          onTaskDeleted={handleTaskDeleted}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- allow removing tasks server-side via new `POST /api/jobs/[taskId]/delete`
- add Trash button in `KanbanDrawer` to trigger deletion
- update board state when a task is removed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886d37bb118832d9cd4dab80cb3d62e