### PR TITLE
Add Daohe column

### DIFF
--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -67,6 +67,7 @@ export default function KanbanBoard() {
     sheet: 'bg-orange-500',
     approval: 'bg-yellow-500',
     outsourcing: 'bg-sky-500',
+    daohe: 'bg-emerald-500',
     program: 'bg-indigo-500',
     operate: 'bg-cyan-500',
     manual: 'bg-pink-500',
@@ -468,7 +469,7 @@ export default function KanbanBoard() {
 
   const visibleColumns = useMemo(() => {
     if (viewMode === 'production') {
-      return columns.filter(c => ['approval', 'outsourcing', 'program', 'operate', 'manual', 'surface', 'inspect', 'ship', 'archive2'].includes(c.id))
+      return columns.filter(c => ['approval', 'outsourcing', 'daohe', 'program', 'operate', 'manual', 'surface', 'inspect', 'ship', 'archive2'].includes(c.id))
     }
     return columns
   }, [viewMode, columns])

--- a/taintedpaint/lib/baseColumns.ts
+++ b/taintedpaint/lib/baseColumns.ts
@@ -14,6 +14,7 @@ export const baseColumns: Column[] = [
   { id: "sheet",       title: "制单",   taskIds: [] },
   { id: "approval",    title: "审批",   taskIds: [] },
   { id: "outsourcing", title: "外协",   taskIds: [] },
+  { id: "daohe",      title: "道禾",   taskIds: [] },
   { id: "program",     title: "编程",   taskIds: [] },
   { id: "operate",     title: "操机",   taskIds: [] },
   { id: "manual",      title: "手工",   taskIds: [] },


### PR DESCRIPTION
## Summary
- add '道禾' column after `外协`
- add new column color and include it in production view filter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688824f09470832db483839273714407