### PR TITLE
Throttled sync polling

### DIFF
--- a/blackpaint/src/sync.ts
+++ b/blackpaint/src/sync.ts
@@ -264,9 +264,13 @@ export function startBidirectionalSync(taskId: string, localRoot: string) {
       await deleteDir(taskId, relPath);
     });
 
+  // Poll less aggressively to reduce server load when many clients are active.
+  // A small random jitter avoids every client hitting the server at once.
+  const SYNC_INTERVAL = 60000; // 60 seconds
+  const jitter = Math.floor(Math.random() * 5000); // up to 5s
   const interval = setInterval(
     () => pullFromServer(taskId, localRoot, pendingUploads),
-    10000,
+    SYNC_INTERVAL + jitter,
   );
   activeSyncs.set(taskId, { watcher, interval, pendingUploads, localRoot });
 }

--- a/file-sync.md
+++ b/file-sync.md
@@ -30,7 +30,7 @@ The project consists of two parts:
   - When a file is added or changed locally, it is uploaded via `POST /api/jobs/{taskId}/upload` with its relative path.
   - If a file is deleted locally, a request is sent to `POST /api/jobs/{taskId}/delete-file`.
 - **Server → Local**
-  - Every 10 seconds the client fetches `/api/jobs/{taskId}/files` to get the authoritative list of files with modification timestamps.
+  - Every 60 seconds (with a small random jitter) the client fetches `/api/jobs/{taskId}/files` to get the authoritative list of files with modification timestamps.
   - New or updated files are downloaded and written to the local folder.
   - Files that were removed on the server are also removed locally.
 


### PR DESCRIPTION
## Summary
- reduce Estara sync polling frequency to once per minute with jitter
- note the new interval in the file sync documentation

## Testing
- `npm test` in `taintedpaint`
- `npm run lint` in `blackpaint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68883534570c832d88705ae134784430