### PR TITLE
Lazily load Kanban board data

### DIFF
--- a/taintedpaint/app/api/jobs/[taskId]/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { readBoardData } from '@/lib/boardDataStore'
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ taskId: string }> }
+) {
+  const { taskId } = await params
+  const boardData = await readBoardData()
+  const task = boardData.tasks[taskId]
+  if (!task) {
+    return NextResponse.json({ error: 'Task not found' }, { status: 404 })
+  }
+  return NextResponse.json(task)
+}

--- a/taintedpaint/app/api/jobs/route.ts
+++ b/taintedpaint/app/api/jobs/route.ts
@@ -19,9 +19,30 @@ const TASKS_STORAGE_DIR = path.join(STORAGE_DIR, "tasks");
 
 // Legacy helper removed in favour of boardDataStore
 
-// GET: Returns the entire board data object (no changes)
-export async function GET() {
+// GET: Returns the board data. If `?summary=1` is passed only lightweight
+// task information is returned.
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const summary = url.searchParams.get('summary') === '1';
   const boardData = await readBoardData();
+  if (summary) {
+    const tasksSummary = Object.fromEntries(
+      Object.entries(boardData.tasks).map(([id, t]) => [
+        id,
+        {
+          id: t.id,
+          columnId: t.columnId,
+          customerName: t.customerName,
+          representative: t.representative,
+          inquiryDate: t.inquiryDate,
+          deliveryDate: t.deliveryDate,
+          notes: t.notes,
+          ynmxId: t.ynmxId,
+        },
+      ])
+    );
+    return NextResponse.json({ tasks: tasksSummary, columns: boardData.columns });
+  }
   return NextResponse.json(boardData);
 }
 

--- a/taintedpaint/types.ts
+++ b/taintedpaint/types.ts
@@ -14,6 +14,18 @@ export interface Task {
   ynmxId?: string; // ID assigned when moving to approval
 }
 
+// A lightweight version used for the Kanban overview
+export interface TaskSummary {
+  id: string;
+  columnId: string;
+  customerName: string;
+  representative: string;
+  inquiryDate: string;
+  deliveryDate?: string;
+  notes: string;
+  ynmxId?: string;
+}
+
 export interface Column {
   id: string;
   title: string;
@@ -23,5 +35,11 @@ export interface Column {
 // NEW: A type for the entire board data
 export interface BoardData {
   tasks: Record<string, Task>;
+  columns: Column[];
+}
+
+// Returned by the /api/jobs?summary=1 endpoint
+export interface BoardSummaryData {
+  tasks: Record<string, TaskSummary>;
   columns: Column[];
 }


### PR DESCRIPTION
## Summary
- add `TaskSummary` and `BoardSummaryData` types
- expose `/api/jobs?summary=1` for lightweight board info
- allow fetching a single task via `/api/jobs/[taskId]`
- load board summary first in `KanbanBoard` and fetch full data in background
- fetch task details when opening the drawer

## Testing
- `npm test --prefix taintedpaint`

------
https://chatgpt.com/codex/tasks/task_e_6888402283c0832dbbfe4c5df3cb08df