### PR TITLE
Fix task type fields

### DIFF
--- a/taintedpaint/types.ts
+++ b/taintedpaint/types.ts
@@ -9,8 +9,8 @@ export interface Task {
   /** Required delivery date, editable in the Kanban drawer */
   deliveryDate?: string;
   notes: string;
-  taskFolderPath: string;
-  files: string[];
+  taskFolderPath?: string;
+  files?: string[];
   ynmxId?: string; // ID assigned when moving to approval
 }
 


### PR DESCRIPTION
## Summary
- make `taskFolderPath` and `files` optional in the Task interface

## Testing
- `npm install` *(fails: 403 Forbidden from registry.npmmirror.com)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888433411ec832fb8845b9d271dc625