### PR TITLE
Improve file listing performance

### DIFF
--- a/taintedpaint/app/api/jobs/[taskId]/create-dir/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/create-dir/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { promises as fs } from 'fs'
 import path from 'path'
 import { sanitizeRelativePath } from '@/lib/pathUtils.mjs'
+import { invalidateFilesCache } from '@/lib/filesCache'
 
 // Use storage directory at the repository root
 const TASKS_STORAGE_DIR = path.join(process.cwd(), '..', 'storage', 'tasks')
@@ -27,6 +28,7 @@ export async function POST(
 
     const dirPath = path.join(TASKS_STORAGE_DIR, taskId, safeRel)
     await fs.mkdir(dirPath, { recursive: true })
+    invalidateFilesCache(taskId)
     return NextResponse.json({ ok: true })
   } catch (err) {
     console.error('create-dir error', err)

--- a/taintedpaint/app/api/jobs/[taskId]/delete-dir/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/delete-dir/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { promises as fs } from 'fs'
 import path from 'path'
 import { sanitizeRelativePath } from '@/lib/pathUtils.mjs'
+import { invalidateFilesCache } from '@/lib/filesCache'
 
 // Use storage directory at the repository root
 const TASKS_STORAGE_DIR = path.join(process.cwd(), '..', 'storage', 'tasks')
@@ -31,6 +32,7 @@ export async function POST(
     } catch (err: any) {
       if (err.code !== 'ENOENT') throw err
     }
+    invalidateFilesCache(taskId)
     return NextResponse.json({ ok: true })
   } catch (err) {
     console.error('delete-dir error', err)

--- a/taintedpaint/app/api/jobs/[taskId]/delete-file/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/delete-file/route.ts
@@ -4,6 +4,7 @@ import path from "path";
 import type { BoardData } from "@/types";
 import { updateBoardData } from "@/lib/boardDataStore";
 import { sanitizeRelativePath } from "@/lib/pathUtils.mjs";
+import { invalidateFilesCache } from "@/lib/filesCache";
 
 // --- Path Definitions ---
 // Root-level storage directory keeps dynamic data outside of Next.js public
@@ -60,6 +61,8 @@ export async function POST(
 
       updatedTask = taskToUpdate;
     });
+
+    invalidateFilesCache(taskId);
 
     return NextResponse.json(updatedTask);
 

--- a/taintedpaint/app/api/jobs/[taskId]/delete/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/delete/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { updateBoardData } from '@/lib/boardDataStore';
+import { invalidateFilesCache } from '@/lib/filesCache';
 
 const STORAGE_DIR = path.join(process.cwd(), '..', 'storage');
 const TASKS_STORAGE_DIR = path.join(STORAGE_DIR, 'tasks');
@@ -26,6 +27,8 @@ export async function POST(
         if (idx !== -1) col.taskIds.splice(idx, 1);
       }
     });
+
+    invalidateFilesCache(taskId);
 
     return NextResponse.json({ ok: true });
   } catch (err) {

--- a/taintedpaint/app/api/jobs/[taskId]/files/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/files/route.ts
@@ -3,6 +3,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { promises as fs } from "fs";
 import path from "path";
+import { getCachedFiles, setCachedFiles } from "@/lib/filesCache";
 
 // Serve files from the root-level storage directory
 const TASKS_STORAGE_DIR = path.join(process.cwd(), "..", "storage", "tasks");
@@ -70,6 +71,11 @@ export async function GET(
   try {
     const taskDirectoryPath = path.join(TASKS_STORAGE_DIR, taskId);
 
+    const cached = getCachedFiles(taskId);
+    if (cached) {
+      return NextResponse.json(cached);
+    }
+
     const urlFromRequest = new URL(req.url);
     const host = req.headers.get('host');
     const baseUrl = host
@@ -81,6 +87,8 @@ export async function GET(
       taskDirectoryPath,
       baseUrl
     );
+
+    setCachedFiles(taskId, files);
 
     return NextResponse.json(files);
   } catch (err: any) {

--- a/taintedpaint/app/api/jobs/[taskId]/update-file/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/update-file/route.ts
@@ -6,6 +6,7 @@ import path from "path";
 import type { BoardData } from "@/types";
 import { updateBoardData } from "@/lib/boardDataStore";
 import { sanitizeRelativePath } from "@/lib/pathUtils.mjs";
+import { invalidateFilesCache } from "@/lib/filesCache";
 
 // Root-level storage directory keeps dynamic data accessible in production
 const STORAGE_DIR = path.join(process.cwd(), "..", "storage");
@@ -82,6 +83,8 @@ export async function POST(
       }
       updatedTask = taskToUpdate;
     });
+
+    invalidateFilesCache(taskId);
 
     return NextResponse.json(updatedTask);
   } catch (err) {

--- a/taintedpaint/app/api/jobs/[taskId]/upload/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/upload/route.ts
@@ -5,6 +5,7 @@ import { promises as fs } from "fs";
 import path from "path";
 import type { BoardData } from "@/types";
 import { updateBoardData, readBoardData } from "@/lib/boardDataStore";
+import { invalidateFilesCache } from "@/lib/filesCache";
 
 // --- Path Definitions ---
 // Root-level storage directory keeps dynamic data accessible in production
@@ -68,6 +69,8 @@ export async function POST(
       taskToUpdate.files.push(...newlyAddedFiles);
       updatedTask = taskToUpdate;
     });
+
+    invalidateFilesCache(taskId);
 
     return NextResponse.json(updatedTask);
   } catch (err) {

--- a/taintedpaint/app/api/jobs/route.ts
+++ b/taintedpaint/app/api/jobs/route.ts
@@ -10,6 +10,7 @@ import path from "path";
 import type { BoardData, Task } from "@/types";
 import { baseColumns, START_COLUMN_ID } from "@/lib/baseColumns";
 import { readBoardData, updateBoardData } from "@/lib/boardDataStore";
+import { invalidateFilesCache } from "@/lib/filesCache";
 
 // --- Path Definitions ---
 // Store uploads under a top-level storage directory rather than /public
@@ -160,6 +161,8 @@ export async function POST(req: NextRequest) {
         boardData.columns[0].taskIds.push(taskId);
       }
     });
+
+    invalidateFilesCache(taskId);
 
     return NextResponse.json(newTask);
   } catch (err) {

--- a/taintedpaint/lib/filesCache.ts
+++ b/taintedpaint/lib/filesCache.ts
@@ -1,0 +1,22 @@
+// Utility for caching file lists per task
+export type CachedFiles = { files: any[]; timestamp: number };
+
+const cache = new Map<string, CachedFiles>();
+
+const TTL_MS = 60_000; // 1 minute
+
+export function getCachedFiles(taskId: string): any[] | null {
+  const entry = cache.get(taskId);
+  if (entry && Date.now() - entry.timestamp < TTL_MS) {
+    return entry.files;
+  }
+  return null;
+}
+
+export function setCachedFiles(taskId: string, files: any[]) {
+  cache.set(taskId, { files, timestamp: Date.now() });
+}
+
+export function invalidateFilesCache(taskId: string) {
+  cache.delete(taskId);
+}


### PR DESCRIPTION
## Summary
- cache job file listings with a simple in-memory map
- invalidate cache when files or directories change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688855128498832f98afca61881bde50