### PR TITLE
Fix KanbanDrawer handler type

### DIFF
--- a/taintedpaint/components/KanbanDrawer.tsx
+++ b/taintedpaint/components/KanbanDrawer.tsx
@@ -479,7 +479,7 @@ export default function KanbanDrawer({
               />
             </label>
             <Button
-              onClick={handleReplaceFolder}
+              onClick={() => handleReplaceFolder()}
               disabled={!replaceFiles || replaceFiles.length === 0 || isReplacing}
               className="w-full h-9"
             >


### PR DESCRIPTION
## Summary
- fix the handler for the replace button by wrapping it in an arrow function

## Testing
- `npm test`
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68886263e91c832f8a16f97a9e72a97a