### PR TITLE
Add SQLite-based login

### DIFF
--- a/taintedpaint/app/api/auth/login/route.ts
+++ b/taintedpaint/app/api/auth/login/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyUser, createSession } from '@/lib/userStore'
+
+export async function POST(req: NextRequest) {
+  const { username, password } = await req.json().catch(() => ({})) as { username?: string, password?: string }
+  if (!username || !password) {
+    return NextResponse.json({ error: 'Missing credentials' }, { status: 400 })
+  }
+  const user = verifyUser(username, password)
+  if (!user) {
+    return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 })
+  }
+  const token = createSession(user.id)
+  const res = NextResponse.json({ ok: true })
+  res.cookies.set('session', token, { httpOnly: true, path: '/' })
+  return res
+}

--- a/taintedpaint/app/api/auth/register/route.ts
+++ b/taintedpaint/app/api/auth/register/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createUser, createSession, findUserByUsername } from '@/lib/userStore'
+
+export async function POST(req: NextRequest) {
+  const { username, password } = await req.json().catch(() => ({})) as { username?: string, password?: string }
+  if (!username || !password) {
+    return NextResponse.json({ error: 'Missing credentials' }, { status: 400 })
+  }
+  if (findUserByUsername(username)) {
+    return NextResponse.json({ error: 'User exists' }, { status: 409 })
+  }
+  const user = createUser(username, password)
+  const token = createSession(user.id)
+  const res = NextResponse.json({ ok: true })
+  res.cookies.set('session', token, { httpOnly: true, path: '/' })
+  return res
+}

--- a/taintedpaint/app/login/page.tsx
+++ b/taintedpaint/app/login/page.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+export default function LoginPage() {
+  const router = useRouter()
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [isRegister, setIsRegister] = useState(false)
+
+  const submit = async () => {
+    setError('')
+    const url = isRegister ? '/api/auth/register' : '/api/auth/login'
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    })
+    if (res.ok) {
+      router.push('/')
+      router.refresh()
+    } else {
+      const data = await res.json().catch(() => ({}))
+      setError(data.error || 'Error')
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-center mt-20 space-y-4">
+      <h1 className="text-xl font-semibold">{isRegister ? 'Register' : 'Login'}</h1>
+      <Input placeholder="Username" value={username} onChange={e => setUsername(e.target.value)} />
+      <Input type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      <Button onClick={submit}>{isRegister ? 'Create Account' : 'Login'}</Button>
+      <button className="text-sm underline" onClick={() => setIsRegister(!isRegister)}>
+        {isRegister ? 'Have an account? Login' : "New user? Create account"}
+      </button>
+    </div>
+  )
+}

--- a/taintedpaint/app/page.tsx
+++ b/taintedpaint/app/page.tsx
@@ -1,9 +1,14 @@
 // app.page.tsx 
 
-"use client"
-
 import KanbanBoard from "@/kanban-board"
+import { cookies } from 'next/headers'
+import { getUserBySession } from '@/lib/userStore'
+import { redirect } from 'next/navigation'
 
 export default function Page() {
+  const cookieStore = cookies()
+  const token = cookieStore.get('session')?.value
+  const user = token ? getUserBySession(token) : null
+  if (!user) redirect('/login')
   return <KanbanBoard />
 }

--- a/taintedpaint/lib/boardDataStore.ts
+++ b/taintedpaint/lib/boardDataStore.ts
@@ -1,19 +1,8 @@
-import { mkdirSync } from 'fs'
-import path from 'path'
-import { STORAGE_ROOT } from './storagePaths'
-import Database from 'better-sqlite3'
+import db from './db'
 import { baseColumns, START_COLUMN_ID, ARCHIVE_COLUMN_ID } from './baseColumns'
 import type { BoardData } from '@/types'
 
-// Store dynamic data outside of the public directory so it remains
-// accessible when running `npm run build && npm run start`.
-const STORAGE_DIR = STORAGE_ROOT
-const DB_PATH = path.join(STORAGE_DIR, 'board.sqlite')
-
-mkdirSync(STORAGE_DIR, { recursive: true })
-
-const db = new Database(DB_PATH)
-db.pragma('journal_mode = WAL')
+// Ensure the board_data table exists in the shared database
 db.exec(`CREATE TABLE IF NOT EXISTS board_data (
   id INTEGER PRIMARY KEY CHECK(id = 1),
   data TEXT NOT NULL

--- a/taintedpaint/lib/db.ts
+++ b/taintedpaint/lib/db.ts
@@ -1,0 +1,12 @@
+import { mkdirSync } from 'fs'
+import path from 'path'
+import { STORAGE_ROOT } from './storagePaths'
+import Database from 'better-sqlite3'
+
+const DB_PATH = path.join(STORAGE_ROOT, 'board.sqlite')
+mkdirSync(STORAGE_ROOT, { recursive: true })
+
+const db = new Database(DB_PATH)
+db.pragma('journal_mode = WAL')
+
+export default db

--- a/taintedpaint/lib/userStore.ts
+++ b/taintedpaint/lib/userStore.ts
@@ -1,0 +1,66 @@
+import crypto from 'crypto'
+import db from './db'
+
+// Create users table if it doesn't exist
+// columns: id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password_hash TEXT
+// sessions table: token TEXT PRIMARY KEY, user_id INTEGER, expires_at INTEGER
+
+db.exec(`CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL
+)`)
+
+db.exec(`CREATE TABLE IF NOT EXISTS sessions (
+  token TEXT PRIMARY KEY,
+  user_id INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
+)`)
+
+export interface User {
+  id: number
+  username: string
+}
+
+export function hashPassword(password: string): string {
+  return crypto.createHash('sha256').update(password).digest('hex')
+}
+
+export function createUser(username: string, password: string): User {
+  const stmt = db.prepare('INSERT INTO users (username, password_hash) VALUES (?, ?)')
+  const result = stmt.run(username, hashPassword(password))
+  return { id: result.lastInsertRowid as number, username }
+}
+
+export function findUserByUsername(username: string): User | undefined {
+  return db.prepare('SELECT id, username FROM users WHERE username = ?').get(username) as User | undefined
+}
+
+export function verifyUser(username: string, password: string): User | null {
+  const row = db.prepare('SELECT id, username, password_hash FROM users WHERE username = ?').get(username) as { id: number, username: string, password_hash: string } | undefined
+  if (!row) return null
+  const hash = hashPassword(password)
+  return row.password_hash === hash ? { id: row.id, username: row.username } : null
+}
+
+export function createSession(userId: number): string {
+  const token = crypto.randomBytes(32).toString('hex')
+  const expires = Date.now() + 7 * 24 * 60 * 60 * 1000 // 7 days
+  db.prepare('INSERT INTO sessions (token, user_id, expires_at) VALUES (?, ?, ?)').run(token, userId, expires)
+  return token
+}
+
+export function getUserBySession(token: string): User | null {
+  const row = db.prepare('SELECT users.id as id, users.username as username, sessions.expires_at as exp FROM sessions JOIN users ON users.id = sessions.user_id WHERE token = ?').get(token) as { id: number, username: string, exp: number } | undefined
+  if (!row) return null
+  if (row.exp < Date.now()) {
+    db.prepare('DELETE FROM sessions WHERE token = ?').run(token)
+    return null
+  }
+  return { id: row.id, username: row.username }
+}
+
+export function deleteSession(token: string) {
+  db.prepare('DELETE FROM sessions WHERE token = ?').run(token)
+}


### PR DESCRIPTION
## Summary
- share SQLite connection in new `db.ts`
- add `userStore` for user/session management
- create login/register API endpoints
- add login page with simple form
- gate root page behind session check

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889ffc00bac832db340b3ca6546cd45