### PR TITLE
fix: point electron client to network server

### DIFF
--- a/blackpaint/src/index.ts
+++ b/blackpaint/src/index.ts
@@ -39,7 +39,7 @@ const createWindow = (): void => {
   }
 
   // and load the index.html of the app.
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://192.168.5.107:3000';
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://192.168.5.21:3001';
   const appUrl = process.env.RESTRICTED ? `${baseUrl}?restricted=1` : baseUrl;
   mainWindow.loadURL(appUrl);
 


### PR DESCRIPTION
## Summary
- default Electron client base URL now points to the network Next.js server

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68998f7e5490832d8e765adf946bb577