### PR TITLE
Display search result counts and fix task status

### DIFF
--- a/taintedpaint/app/holistic/page.tsx
+++ b/taintedpaint/app/holistic/page.tsx
@@ -41,7 +41,7 @@ interface Job extends Task {
 }
 
 const getStatus = (t: Task): Status => {
-  if (t.columnId === "archive2") return "Finished"
+  if (["archive2", "ship"].includes(t.columnId)) return "Finished"
   if (t.columnId === "archive") return "Quoted"
   return "Working"
 }
@@ -184,6 +184,7 @@ export default function ArchivePage() {
               className="w-full max-w-sm border-0 border-b border-gray-300 bg-transparent px-0 py-2 text-sm
                          focus:border-gray-900 focus:ring-0 placeholder-gray-400"
             />
+            <p className="mt-1 text-xs text-gray-500">{filtered.length} 条结果</p>
           </div>
         </div>
 

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -616,6 +616,9 @@ export default function KanbanBoard() {
               className="w-full px-3 py-2 text-sm bg-gray-50 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             />
             <p className="mt-2 text-xs text-gray-400">如：海康 徐鹏</p>
+            {searchQuery && (
+              <p className="mt-1 text-xs text-gray-500">{searchResults.length} 条结果</p>
+            )}
           </div>
           
           <div className="overflow-y-auto h-[calc(100%-88px)]">


### PR DESCRIPTION
## Summary
- show filtered result count on archive search page
- show search result count in kanban sidebar
- treat shipped tasks as finished to fix status metrics

## Testing
- `npm test`
- `npm run lint` *(fails: configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68b16ed28708832d9774e3d57c4795a6